### PR TITLE
feat: 회원가입 구현[ISSUE-6]

### DIFF
--- a/src/main/java/com/s1dmlgus/instagram02/config/SecurityConfig.java
+++ b/src/main/java/com/s1dmlgus/instagram02/config/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.s1dmlgus.instagram02.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/Gender.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/Gender.java
@@ -1,0 +1,7 @@
+package com.s1dmlgus.instagram02.domain.user;
+
+public enum Gender {
+
+    MAN,
+    WOMAN
+}

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/Role.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/Role.java
@@ -1,0 +1,7 @@
+package com.s1dmlgus.instagram02.domain.user;
+
+public enum Role {
+
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -36,4 +36,9 @@ public class User{
     @Enumerated(EnumType.STRING)
     private Role role;                  // 권한
 
+
+    // 비밀번호 암호화
+    public void bcryptPw(String encode) {
+        this.password = encode;
+    }
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -41,4 +41,8 @@ public class User{
     public void bcryptPw(String encode) {
         this.password = encode;
     }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -1,6 +1,39 @@
 package com.s1dmlgus.instagram02.domain.user;
 
-public class User {
+import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+import lombok.*;
 
+import javax.persistence.*;
+
+@Builder
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class User{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    private String username;            // 닉네임
+
+    private String password;            // 패스워드
+
+    private String email;               // 이메일
+
+    private String name;                // 이름
+
+    private String bio;                 // 자기소개
+    private String website;             // 웹사이트
+    private String phone;               // 핸드폰 번호
+    private String profileImageUrl;     // 프로필 사진
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;              // 성별
+    @Enumerated(EnumType.STRING)
+    private Role role;                  // 권한
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/UserRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/UserRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-
+    boolean existsByUsername(String username);
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/UserRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.s1dmlgus.instagram02.domain.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -1,5 +1,6 @@
 package com.s1dmlgus.instagram02.service;
 
+import com.s1dmlgus.instagram02.domain.user.Role;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.web.dto.JoinDto;
@@ -23,9 +24,13 @@ public class UserService {
 
         // 1. 중복확인
         duplicateUser(user);
-
         // 2. 암호화
         bcryptPw(user);
+        // 3. 권한 설정
+        user.setRole(Role.USER);
+
+        // 4. 영속화
+        userRepository.save(user);
     }
 
 

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -1,0 +1,35 @@
+package com.s1dmlgus.instagram02.service;
+
+import com.s1dmlgus.instagram02.domain.user.User;
+import com.s1dmlgus.instagram02.domain.user.UserRepository;
+import com.s1dmlgus.instagram02.web.dto.JoinDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // 회원가입
+    public void join(JoinDto joinDto){
+
+        User user = joinDto.toEntity();
+
+        // 1. 중복확인
+        duplicateUser(user);
+
+        // 2. 암호화
+
+    }
+
+    protected void duplicateUser(User user){
+        boolean existsUsername = userRepository.existsByUsername(user.getUsername());
+
+        if(existsUsername){
+            throw new RuntimeException("현재 사용중인 닉네임입니다.");
+        }
+    }
+}

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -4,6 +4,7 @@ import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.web.dto.JoinDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,8 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     // 회원가입
+    @Transactional
     public void join(JoinDto joinDto){
 
         User user = joinDto.toEntity();
@@ -22,12 +25,19 @@ public class UserService {
         duplicateUser(user);
 
         // 2. 암호화
+        bcryptPw(user);
+    }
 
+
+    protected void bcryptPw(User user) {
+
+        String encode = bCryptPasswordEncoder.encode(user.getUsername());
+        user.bcryptPw(encode);
     }
 
     protected void duplicateUser(User user){
-        boolean existsUsername = userRepository.existsByUsername(user.getUsername());
 
+        boolean existsUsername = userRepository.existsByUsername(user.getUsername());
         if(existsUsername){
             throw new RuntimeException("현재 사용중인 닉네임입니다.");
         }

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/JoinDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/JoinDto.java
@@ -1,0 +1,25 @@
+package com.s1dmlgus.instagram02.web.dto;
+
+
+import com.s1dmlgus.instagram02.domain.user.User;
+import lombok.Data;
+
+@Data
+public class JoinDto {
+
+    private String username;
+    private String password;
+    private String email;
+    private String name;
+
+
+    public User toEntity(){
+
+        return User.builder()
+                .username(username)
+                .password(password)
+                .email(email)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/JoinDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/JoinDto.java
@@ -2,8 +2,12 @@ package com.s1dmlgus.instagram02.web.dto;
 
 
 import com.s1dmlgus.instagram02.domain.user.User;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Data
 public class JoinDto {
 

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceTest.java
@@ -1,0 +1,51 @@
+package com.s1dmlgus.instagram02.service;
+
+import com.s1dmlgus.instagram02.domain.user.User;
+import com.s1dmlgus.instagram02.domain.user.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+@Transactional
+@SpringBootTest
+class UserServiceTest {
+
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserService userService;
+
+
+    @DisplayName("닉네임 중복검사")
+    @Test
+    public void duplicateUsernameTest() throws Exception{
+        //given
+
+        User user1 = createUser();
+        User user2 = createUser();
+        //when
+        userRepository.save(user1);
+
+
+        //then
+        assertThatThrownBy(() -> userService.duplicateUser(user2))
+                .isInstanceOf(Exception.class)
+                .hasMessage("현재 사용중인 닉네임입니다.");
+    }
+
+    private User createUser() {
+        return User.builder()
+                .username("t1dmlgus")
+                .password("1234")
+                .email("dmlgus@gmail.com")
+                .name("이의현")
+                .build();
+    }
+
+}

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceTest.java
@@ -10,7 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+
+
 @Transactional
 @SpringBootTest
 class UserServiceTest {
@@ -46,6 +47,19 @@ class UserServiceTest {
                 .email("dmlgus@gmail.com")
                 .name("이의현")
                 .build();
+    }
+
+    @DisplayName("비밀번호 암호화")
+    @Test
+    public void bcryptPwTest() throws Exception{
+        //given
+        User user = createUser();
+
+        //when
+        userService.bcryptPw(user);
+
+        //then
+        assertThat(user.getPassword()).isNotEqualTo("1234");
     }
 
 }

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.s1dmlgus.instagram02.service;
 
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
+import com.s1dmlgus.instagram02.web.dto.JoinDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,9 +24,9 @@ class UserServiceTest {
     private UserService userService;
 
 
-    @DisplayName("닉네임 중복검사")
+    @DisplayName("닉네임 중복검사 테스트")
     @Test
-    public void duplicateUsernameTest() throws Exception{
+    public void duplicateUsernameTest() throws Exception {
         //given
 
         User user1 = createUser();
@@ -49,9 +50,9 @@ class UserServiceTest {
                 .build();
     }
 
-    @DisplayName("비밀번호 암호화")
+    @DisplayName("비밀번호 암호화 테슽")
     @Test
-    public void bcryptPwTest() throws Exception{
+    public void bcryptPwTest() throws Exception {
         //given
         User user = createUser();
 
@@ -61,5 +62,24 @@ class UserServiceTest {
         //then
         assertThat(user.getPassword()).isNotEqualTo("1234");
     }
+
+    @DisplayName("회원가입 테스트")
+    @Test
+    public void joinTest() throws Exception {
+        //given
+        JoinDto joinDto = new JoinDto("s1dmlgus", "1234", "dmlgus@gamil.com", "이의현");
+
+        //when
+        userService.join(joinDto);
+        User user = userRepository.findById(1L).get();
+
+        //then
+        assertThat(user.getUsername()).isEqualTo("s1dmlgus");
+
+    }
+
+
+
+
 
 }


### PR DESCRIPTION
### 이슈 번호
resolved: #6 

### 개요
회원가입을 한다.

### 작업 내용

UserService.java
 - 회원가입(join) 서비스에서 중복확인(닉네임), 암호화(패스워드), 권한설정 로직 후 회원가입을 한다.
 - 중복검사(닉네임), 암호화(패스워드)는 protected 범위로 메소드 화(테스트 용이)

JoinDto.java
- 회원가입 시 필요한 정보를 담는 DTO 

SecurityConfig.java
- BcryptPasswordEncoder를 사용하기 위해 빈 등록
- @EnableWebSecurity



### 테스트
- [x] 닉네임 중복검사
- [x] 비밀번호 암호화 
- [x] 회원가입

### 주의사항
User 엔티티 중 성별(Gender), 권한(Role)을 Enum 타입으로 생성
