### PR TITLE
feat: JPA Auditing으로 생성시간/수정시간 자동화[ISSUE-9]

### DIFF
--- a/src/main/java/com/s1dmlgus/instagram02/Instagram02Application.java
+++ b/src/main/java/com/s1dmlgus/instagram02/Instagram02Application.java
@@ -2,7 +2,9 @@ package com.s1dmlgus.instagram02;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Instagram02Application {
 

--- a/src/main/java/com/s1dmlgus/instagram02/domain/BaseTimeEntity.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.s1dmlgus.instagram02.domain;
+
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/domain/comment/Comment.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/comment/Comment.java
@@ -1,4 +1,6 @@
 package com.s1dmlgus.instagram02.domain.comment;
 
-public class Comment {
+import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+
+public class Comment extends BaseTimeEntity {
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/image/Image.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/image/Image.java
@@ -1,4 +1,6 @@
 package com.s1dmlgus.instagram02.domain.image;
 
-public class Image {
+import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+
+public class Image extends BaseTimeEntity {
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/likes/Likes.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/likes/Likes.java
@@ -1,4 +1,6 @@
 package com.s1dmlgus.instagram02.domain.likes;
 
-public class Likes {
+import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+
+public class Likes extends BaseTimeEntity {
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/Subscribe.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/Subscribe.java
@@ -1,4 +1,6 @@
 package com.s1dmlgus.instagram02.domain.subscribe;
 
-public class Subscribe {
+import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+
+public class Subscribe extends BaseTimeEntity {
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
-public class User{
+public class User extends BaseTimeEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/com/s1dmlgus/instagram02/domain/BaseTimeEntityTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/domain/BaseTimeEntityTest.java
@@ -1,0 +1,44 @@
+package com.s1dmlgus.instagram02.domain;
+
+import com.s1dmlgus.instagram02.domain.user.User;
+import com.s1dmlgus.instagram02.domain.user.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.PublicKey;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+class BaseTimeEntityTest {
+
+
+    @Autowired
+    public UserRepository userRepository;
+
+    @DisplayName("BaseTimeEntity 등록 테스트")
+    @Test
+    public void createBaseTimeEntityTest() throws Exception{
+        //given
+        LocalDateTime now = LocalDateTime.now();
+        //when
+        User save = userRepository.save(User.builder()
+                .username("t1dmlgus")
+                .password("1234")
+                .email("dmlgus@gmail.com")
+                .name("의현")
+                .build());
+
+
+        //then
+        Assertions.assertThat(save.getCreatedDate()).isAfter(now);
+    }
+
+}


### PR DESCRIPTION
### 이슈 번호
resolved: #9

### 개요
JPA Auditing을 사용하여, 엔티티에 컬럼(생성시간, 수정시간)을 만들어 DB에 시간을 기록한다.

### 작업 내용

BaseTimeEntity.java
- JPA Auditing을 기능을 @EntityListener(AuditingEntityListener.class)을 통해 추가한다.
- 각 엔티티는 BaseTimeEntity를 상속받는다.

Application.java
- Application 클래스에 @EnableJpaAuditing을 추가한다.






### 테스트

- [x] BaseTimeEntity 등록 테스트

### 주의사항
@MappedSuperclass
- JPA 엔티티 클래스들이 BaseTimeEntity을 상속할 경우 생성시간, 수정시간을 컬럼으로 인식한다.

@EntityListener(AuditingEntityListener.class)
- BaseTimeEntity 클래스에 Auditing 기능을 포함시킨다.

@EnableJpaAuditing
- JPA Auditing 어노테이션을 모두 활성화한다.
