### PR TITLE
feat: 회원가입 페이지 구현[ISSUE-13]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 application.yml
+
+/src/main/resources/static/css
+/src/main/resources/static/images

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/AuthController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/AuthController.java
@@ -1,0 +1,16 @@
+package com.s1dmlgus.instagram02.web.controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AuthController {
+
+    // 회원가입
+    @GetMapping("/auth/signup")
+    public String join(){
+        return "auth/signup";
+    }
+
+}

--- a/src/main/resources/templates/auth/signup.html
+++ b/src/main/resources/templates/auth/signup.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>insta02_회원가입</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css"
+         integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous" />
+    <!-- 제이쿼리 -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+</head>
+<body>
+  <div class="container">
+    <main class="loginMain">
+      <!--회원가입섹션-->
+      <section class="login">
+        <article class="login__form__container">
+
+          <!--회원가입 폼-->
+          <div class="login__form">
+            <!--로고-->
+            <h1><img src="/images/logo.jpg" alt=""></h1>
+            <!--로고end-->
+
+            <!--회원가입 인풋-->
+            <form id="profileUpdate" class="login__input" onsubmit="join(event)">
+              <input type="text" name="username" placeholder="유저네임" required="required" length="20"/>
+              <input type="password" name="password" placeholder="패스워드" required="required" />
+              <input type="email" name="email" placeholder="이메일" required="required" />
+              <input type="text" name="name" placeholder="이름" required="required" />
+              <button>가입</button>
+            </form>
+            <!--회원가입 인풋end-->
+          </div>
+          <!--회원가입 폼end-->
+
+          <!--계정이 있으신가요?-->
+          <div class="login__register">
+            <span>계정이 있으신가요?</span>
+            <a href="/auth/signin">로그인</a>
+          </div>
+          <!--계정이 있으신가요?end-->
+
+        </article>
+      </section>
+    </main>
+  </div>
+
+  <script src="/js/join.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/layout/footer.html
+++ b/src/main/resources/templates/layout/footer.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<footer th:fragment="footer">
+    <div class="container">
+        <ul>
+            <li><a href="#a">소개</a></li>
+            <li><a href="#a">블로그</a></li>
+            <li><a href="#a">채용 정보</a></li>
+            <li><a href="#a">도움말</a></li>
+            <li><a href="#a">API</a></li>
+            <li><a href="#a">개인정보처리방침</a></li>
+            <li><a href="#a">약관</a></li>
+            <li><a href="#a">인기 계정</a></li>
+            <li><a href="#a">해시태그</a></li>
+            <li><a href="#a">위치</a></li>
+        </ul>
+        <div class="copy">
+            <p>© 2020 Photogram from There Programing</p>
+        </div>
+    </div>
+</footer>
+
+</body>
+</html>

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:fragment="head(title)">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>instagram02</title>
+    <!--    <title th:text="${title}"></title>-->
+
+    <!-- 제이쿼리 -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Style -->
+    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/story.css">
+    <link rel="stylesheet" href="/css/popular.css">
+    <link rel="stylesheet" href="/css/profile.css">
+    <link rel="stylesheet" href="/css/upload.css">
+    <link rel="stylesheet" href="/css/update.css">
+    <link rel="shortcut icon" href="/images/insta.svg">
+
+    <!-- Fontawesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" />
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@100;200;300;400;500;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+
+
+    <header th:fragment="body_header" class="header">
+        <div class="container">
+            <!-- 로고 -->
+            <a href="/image/story" class="logo">
+                <img src="/images/logo.jpg" alt="">
+            </a>
+
+            <!-- 세션유저 js 활용-->
+            <input type="hidden" id="principal" th:value="${principal.user.id}">
+
+
+            <!-- nav -->
+            <nav class="navi">
+                <ul class="navi-list">
+                    <li class="navi-item"><a href="/image/story">
+                        <i class="fas fa-home"></i>
+                    </a></li>
+                    <li class="navi-item"><a href="/image/popular">
+                        <i class="far fa-compass"></i>
+                    </a></li>
+<!--                    <button th:onclick="|location.href='/user/${user.id}/update'|">회원정보 변경</button>-->
+                    <li class="navi-item"><a th:href="|/user/${principal.user.id}|">
+                        <i class="far fa-user"></i>
+                    </a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+</body>


### PR DESCRIPTION
### 이슈 번호
resolved: #13 

### 개요
회원가입 페이지를 구현한다.


### 작업 내용

signup.html
thymleaf 사용해서 회원가입 페이지를 구현한다.

AuthController.java 
GET Mapping을 사용하여 외부에서 '/auth/signup' 요청 시 회원가입 페이지를 리턴한다.

### 테스트

### 주의사항
정적파일(*.css, *.jpg 등) 을 gitignore 파일에 추가한다. 
