### PR TITLE
feat:  Oauth2 클라이언트를 이용한 소셜 로그인 기능 구현 [ISSUE-24]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
+
+
+
 
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 

--- a/src/main/java/com/s1dmlgus/instagram02/config/SecurityConfig.java
+++ b/src/main/java/com/s1dmlgus/instagram02/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.s1dmlgus.instagram02.config;
 
 
+import com.s1dmlgus.instagram02.config.oauth.Oauth2DetailsService;
 import com.s1dmlgus.instagram02.handler.auth.CustomAuthFailureHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,8 +15,12 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 
+@RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final Oauth2DetailsService oauth2DetailsService;
+
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
@@ -41,7 +46,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .loginPage("/auth/signin")
                 .loginProcessingUrl("/auth/signin")
                 .defaultSuccessUrl("/", false)
-                .failureHandler(customAuthFailureHandler());
+                .failureHandler(customAuthFailureHandler())
+                .and()
+                .oauth2Login()
+                .userInfoEndpoint()
+                .userService(oauth2DetailsService);
 
 
     }

--- a/src/main/java/com/s1dmlgus/instagram02/config/auth/PrincipalDetails.java
+++ b/src/main/java/com/s1dmlgus/instagram02/config/auth/PrincipalDetails.java
@@ -5,20 +5,27 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 
-@NoArgsConstructor
+
 @Data
-public class PrincipalDetails implements UserDetails{
+public class PrincipalDetails implements UserDetails, OAuth2User {
 
     private User user;
+    private Map<String, Object> attributes;
 
     public PrincipalDetails(User user) {
         this.user = user;
+    }
+
+    public PrincipalDetails(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
     }
 
     // 유저 권한 리턴
@@ -61,4 +68,14 @@ public class PrincipalDetails implements UserDetails{
     }
 
 
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
 }

--- a/src/main/java/com/s1dmlgus/instagram02/config/oauth/Oauth2DetailsService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/config/oauth/Oauth2DetailsService.java
@@ -1,0 +1,55 @@
+package com.s1dmlgus.instagram02.config.oauth;
+
+
+import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
+import com.s1dmlgus.instagram02.domain.user.Role;
+import com.s1dmlgus.instagram02.domain.user.User;
+import com.s1dmlgus.instagram02.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class Oauth2DetailsService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        System.out.println("oAuth2User.getAttributes() = " + oAuth2User.getAttributes());
+
+        Map<String, Object> userInfo = oAuth2User.getAttributes();
+
+        String username = "facebook_" + (String) userInfo.get("id");
+        String password = new BCryptPasswordEncoder().encode(UUID.randomUUID().toString());
+        String email = (String) userInfo.get("email");
+        String name = (String) userInfo.get("name");
+
+        User userEntity = userRepository.findByUsername(username);
+
+        if (userEntity == null) {
+            User user = User.builder()
+                    .username(username)
+                    .password(password)
+                    .email(email)
+                    .name(name)
+                    .role(Role.ROLE_USER)
+                    .build();
+
+            return new PrincipalDetails(userRepository.save(user), oAuth2User.getAttributes());           // 리턴 -> 세션에 저장
+        } else {                             // 페이스북으로 이미 회원가입이 되어있음
+            return new PrincipalDetails(userEntity, oAuth2User.getAttributes());
+
+        }
+    }
+}


### PR DESCRIPTION
### 이슈 번호
resolved: #24 

### 개요

oauth 클라이언트를 이용하여 소셜 로그인을 구현한다.

### 작업 내용

SecurityConfig.java

- oauth2 클라이언트에 대한 Configuration 설정을 한다.

Oauth2DetailsService.java

- loadUser 재정의하여 소셜로그인 시 받은 정보를 이용하여 자동 로그인을 실행한다.

PrincipalDetails.java 

- OAuth2User의 상속을 추가한다. 

### 테스트

### 주의사항

- yml 에 해당 소셜네트워스서비스에서 받은 clientId 와 client-secret를 저장하고, scope를 지정한다.
- userInfoEndpoint 를 이용하여 oauth 전반적인 흐름은 시큐리티에 위임하고 endPoint를 유저정보(userInfo)로 받겠다.
