### PR TITLE
feat: 1차 배포 [ISSUE-26] 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ out/
 ### VS Code ###
 .vscode/
 
+/src/main/resources/application-local.yml
+/src/main/resources/application-dv.yml
 application.yml
 
 /src/main/resources/static/css

--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
-
-
+	implementation 'org.mariadb.jdbc:mariadb-java-client'
 
 
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
@@ -46,6 +45,9 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+
+
 }
 
 test {

--- a/src/test/java/com/s1dmlgus/instagram02/web/controller/api/AuthApiControllerIntegrationTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/web/controller/api/AuthApiControllerIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -26,14 +27,13 @@ import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentRespon
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-
 @Transactional
-@ExtendWith(RestDocumentationExtension.class)    // JUnit5 필수
 @SpringBootTest
 public class AuthApiControllerIntegrationTest {
 
@@ -44,15 +44,13 @@ public class AuthApiControllerIntegrationTest {
 
     private MockMvc mockMvc;
 
-
     @BeforeEach
-    void setup(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+    void setup(WebApplicationContext webApplicationContext) {
 
         this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .apply(documentationConfiguration(restDocumentation))
+                .apply(springSecurity())
                 .build();
     }
-
 
     @DisplayName("회원가입 요청 테스트")
     @Test
@@ -64,38 +62,16 @@ public class AuthApiControllerIntegrationTest {
         //when(테스트)
         ResultActions resultAction = mockMvc.perform(
                 post("/api/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
                         .content(json)
-
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
         );
-
-
-
 
         //then(검증)
         resultAction
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("회원가입이 정상적으로 되었습니다."))
-                .andDo(MockMvcResultHandlers.print())
-                .andDo(document("{class-name}/{method-name}",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestFields(
-                                fieldWithPath("username").type(JsonFieldType.STRING).description("넥네임"),
-                                fieldWithPath("password").type(JsonFieldType.STRING).description("패스워드"),
-                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
-                                fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
-                ),
-                        responseFields(
-                                fieldWithPath("message").type(JsonFieldType.STRING).description("결과 소시지"),
-                                fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("회원번호"),
-                                fieldWithPath("data.username").type(JsonFieldType.STRING).description("닉네임"),
-                                fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름"),
-                                fieldWithPath("data.email").type(JsonFieldType.STRING).description("이메일"),
-                                fieldWithPath("data.role").type(JsonFieldType.STRING).description("권한")
-                        )
-                ));
-
+                .andDo(MockMvcResultHandlers.print());
 
     }
 

--- a/src/test/java/com/s1dmlgus/instagram02/web/controller/api/AuthApiControllerUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/web/controller/api/AuthApiControllerUnitTest.java
@@ -1,6 +1,7 @@
 package com.s1dmlgus.instagram02.web.controller.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.s1dmlgus.instagram02.config.SecurityConfig;
 import com.s1dmlgus.instagram02.handler.exception.CustomValidationException;
 import com.s1dmlgus.instagram02.service.UserService;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
@@ -12,10 +13,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -26,24 +31,34 @@ import org.springframework.web.context.WebApplicationContext;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentRequest;
+import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(RestDocumentationExtension.class)    // JUnit5 필수
-@WebMvcTest(AuthApiController.class)
+@WithMockUser(roles = "USER")
+@WebMvcTest(value = AuthApiController.class, excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
 class AuthApiControllerUnitTest {
 
-    @Autowired
     private MockMvc mockMvc;
 
     @MockBean   // IoC 환경에 bean 등록됨
     private UserService userService;
+
+    @BeforeEach
+    void setup(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
 
 
     // BDDMockito 패턴
@@ -61,19 +76,29 @@ class AuthApiControllerUnitTest {
 
         //when(테스트)
         ResultActions resultAction = mockMvc.perform(
-                post("http://localhost:8080/api/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
+                post("/api/auth/signup")
+                        .with(csrf())
                         .content(json)
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
+                        .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
         );
-
 
         //then(검증)
         resultAction
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("회원가입이 정상적으로 되었습니다."))
-                .andDo(MockMvcResultHandlers.print());
+                .andDo(MockMvcResultHandlers.print())
+                .andDo(document("{class-name}/{method-name}",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestFields(
+                        fieldWithPath("username").type(JsonFieldType.STRING).description("넥네임"),
+                        fieldWithPath("password").type(JsonFieldType.STRING).description("패스워드"),
+                        fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                        fieldWithPath("name").type(JsonFieldType.STRING).description("이름")
+                )
+        ));
     }
-
 
     @DisplayName("회원가입 username 유효성 검사 예외 처리 테스트")
     @Test
@@ -90,13 +115,15 @@ class AuthApiControllerUnitTest {
         when(userService.join(joinRequestDto)).thenThrow(new CustomValidationException("유효성 검사 실패", errorMap));
 
         //when(테스트)
-        ResultActions resultAction = mockMvc.perform(
-                post("http://localhost:8080/api/auth/signup")
-                        .contentType(MediaType.APPLICATION_JSON)
+        ResultActions resultAction =
+                mockMvc.perform(
+                post("/api/auth/signup")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON_UTF8)
                         .content(json)
                         .accept(MediaType.APPLICATION_JSON_UTF8_VALUE)
-        );
 
+        );
 
         //then(검증)
         resultAction
@@ -105,25 +132,24 @@ class AuthApiControllerUnitTest {
                 .andExpect(jsonPath("$.data.username").value("0에서 20자까지 작성할 수 있습니다"))
                 .andDo(MockMvcResultHandlers.print());
 
-
     }
 
     private JoinRequestDto createJoinDto() {
         JoinRequestDto joinRequestDto = new JoinRequestDto();
-        joinRequestDto.setUsername("22222222");
+        joinRequestDto.setUsername("t1dmlgus");
         joinRequestDto.setPassword("1234");
-        joinRequestDto.setEmail("gngl@mgail.com");
-        joinRequestDto.setName("t1dmlgus");
+        joinRequestDto.setEmail("dmlgusgngl@mgail.com");
+        joinRequestDto.setName("이의현");
         return joinRequestDto;
     }
 
 
     private JoinRequestDto createExceptionJoinDto() {
         JoinRequestDto joinRequestDto = new JoinRequestDto();
-        joinRequestDto.setUsername("2222222222222222222222222222222222222");
+        joinRequestDto.setUsername("t22222222222222222222222222222222222dmlgus");
         joinRequestDto.setPassword("1234");
-        joinRequestDto.setEmail("gngl@mgail.com");
-        joinRequestDto.setName("t1dmlgus");
+        joinRequestDto.setEmail("dmlgusgngl@mgail.com");
+        joinRequestDto.setName("이의현");
         return joinRequestDto;
     }
 


### PR DESCRIPTION
### 이슈 번호
resolved: #26 

### 개요
aws ec2에 프로젝트 build 후 배포한다.

### 작업 내용

- RDS(mariaDB) 생성 후, 프로젝트와 연결 -> application-local.yml
- 시큐리티 설정 후 AuthApiControllerUnitTest.java 리펙토링
- AuthApiCotrollerIntegrationTest -> AuthApiControllerUnitTest.java 로 SpringRestDocs 작성 변경
- 개발환경 별 yml 설정 -> 테스트(application-test.yml), 운영(application-dev.yml)

<br>

### 테스트

- [x] AuthApiControllerUnitTest.java

<br> 

### 주의사항

SpringRestDocs 생성 시 통합테스트 -> 단위테스트로 변경(Controller)

- ./gradlew test 시 PayloadHandlingException 예외발생
- 예외 내용 : Cannot handle application/json;charset=UTF-8 content as it could not be parsed as JSON or XML 
- 아직 해결 못함
-> ec2 배포 시 예외 발생안함

facebook 로그인 시 facebook API에서 HTTPS 만 지원한다.
- 개발모드에서는 HTTP에서도 설정할수 있다 -> 적용 못함
- SSL 인증서를 받급받아 ec2 인스턴스에 HTTPS 를 적용한다. 


<br>

### 트러블 슈팅

#### 문제1
시큐리티 설정 추가 후, 기존  test 실패
securityConfig 내 DefaultOAuth2UserService 상속받은 빈을 찾지 못함

#### 해결

- AuthApiControllerUnitTest.java @WebMvcTest에 스캔대상에서 SecurityConfig.class 를 제거

아래 두 리펙토링을 적용하지 않았음에도 테스트 성공
- .with(csrf())
- @WithMockUser(roles = "USER")

#### 문제 2
- ec2 에 배포 후 프로젝트 build 시 통합테스트 실패 

#### 해결
- 개발환경 테스트(test), 운영(dev) yml 생성 후 적용


