### PR TITLE
test: 이미지 업로드 단위 테스트 [ISSUE-33]

### DIFF
--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiController.java
@@ -34,12 +34,12 @@ public class ImageApiController {
     private final ImageService imageService;
 
     @PostMapping("/save")
-    public ResponseEntity<?> imageUpload(@Valid ImageUploadDto imageUploadDto, BindingResult bindingResult) {
+    public ResponseEntity<?> imageUpload(@Valid ImageUploadDto imageUploadDto, BindingResult bindingResult, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         logger.info("immageUploadDto {}", imageUploadDto);
 
         // 업로드
-        ResponseDto<?> uploadImage = imageService.upload(imageUploadDto);
+        ResponseDto<?> uploadImage = imageService.upload(imageUploadDto, principalDetails);
 
         logger.info("[이미지 업로드 완료] uploadImage : {}", uploadImage);
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/image/ImageUploadDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/image/ImageUploadDto.java
@@ -21,7 +21,7 @@ public class ImageUploadDto {
     private String userId;
     @NotBlank(message = "타이틀을 입력해주세요.")
     private String caption;
-    private MultipartFile files;
+    private MultipartFile file;
 
 
     public Image toEntity(String postImageUrl, User user){

--- a/src/test/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiControllerUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiControllerUnitTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Spy;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
@@ -18,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,13 +27,19 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentRequest;
+import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
 @ExtendWith(RestDocumentationExtension.class)    // JUnit5 필수
-@WithMockUser(roles = "USER")
 @WebMvcTest(value = ImageApiController.class, excludeFilters = {
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
 class ImageApiControllerUnitTest {
@@ -53,17 +61,17 @@ class ImageApiControllerUnitTest {
     @Test
     public void imageUploadTest() throws Exception{
         //given
-        MockMultipartFile files = new MockMultipartFile("파일제목", "파일제목.jpeg", "image/jpeg", "<<jpeg data>>".getBytes());
+        MockMultipartFile files = new MockMultipartFile("file", "파일명.jpeg", "image/jpeg", "<<파일데이터>>".getBytes());
         ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", files);
 
         //when
-        //when(imageService.upload(imageUploadDto)).thenReturn(new ResponseDto<>("이미지가 업로드 되었습니다.", null));
+        when(imageService.upload(any(ImageUploadDto.class), any())).thenReturn(new ResponseDto<>("이미지가 업로드 되었습니다.", null));
 
 
         //then
         ResultActions resultActions = mockMvc.perform(
                 multipart("/api/image/save")
-                        .file("files", files.getBytes())
+                        .file(files)
                         .param("userId", "1L")
                         .param("caption", "이미지업로드테스트입니다")
                         .contentType(MediaType.MULTIPART_FORM_DATA)
@@ -73,9 +81,10 @@ class ImageApiControllerUnitTest {
 
         resultActions
                 .andExpect(status().isOk())
-                .andDo(MockMvcResultHandlers.print());
+                .andDo(MockMvcResultHandlers.print())
+                .andDo(document("{class-name}/{method-name}", getDocumentRequest(), getDocumentResponse()
 
-
+        ));
 
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,3 +32,5 @@ spring:
               - public_profile
               - email
 
+file:
+  path: C:/workspace/springbootwork/upload/


### PR DESCRIPTION
### 이슈 번호
resolved: #33 

### 개요

이미지 업로드 기능 테스트 리펙토링

### 작업 내용

ImageServiceUnitTest

- 이미지 업로드 테스트
- 파일 생성 테스트
- 파일 유효성 검사 테스트
- 파일 업로드 실패 테스트

ImageApiControllerUnitTest
 
- WebMvc 이미지 업로드 테스트
- mockMvc로 url요청 시  multipart 요청으로 file과 param으로 따로 나누어 요청하였음
- 요청 결과, ImageApiController의 이미지 요청 DTO(ImageUploadDto)에 잘 바인딩 되었지만, MockHttpServletRequest에 body가 null로 표시되었음
(요청 DTO가 아닌, Multipart 타입과 데이터 타입을 나눠 @RequestPart도 고려해봐 할 듯)
- body가 null이여서 Spring rest Docs의 요청 파라미터를 작성못함
- 추후 리펙토링 필요

![image](https://user-images.githubusercontent.com/59961350/143443545-56adaac1-3008-430b-892c-00ad85ec8a95.png)

### 테스트

- [x] ImageServiceUnitTest.java 
- [x] ImageApiControllerUnitTest.java

### 주의사항

- ReflectionTestUtils.setField를 이용하여 @Value에 접근할 수 있었다.
- MockMultipartFile name과 요청 DTO(ImageUploadDto)의 MultipartFile 변수명과  동일해야 바인딩 된다.