### PR TITLE
feat: 유저 프로필 페이지 렌더링 [ISSUE-38]

### DIFF
--- a/src/main/java/com/s1dmlgus/instagram02/config/WebMvcConfig.java
+++ b/src/main/java/com/s1dmlgus/instagram02/config/WebMvcConfig.java
@@ -1,0 +1,28 @@
+package com.s1dmlgus.instagram02.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.PathResourceResolver;
+
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Value("${file.path}")
+    private String uploadFolder;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        WebMvcConfigurer.super.addResourceHandlers(registry);
+
+        registry
+                .addResourceHandler("/upload/**")
+                .addResourceLocations("file:///" + uploadFolder)
+                .setCachePeriod(60 * 10 * 6)   // 초단위-> 60초 * 10개 * 6개
+                .resourceChain(true)            // 발동
+                .addResolver(new PathResourceResolver());
+
+    }
+}

--- a/src/main/java/com/s1dmlgus/instagram02/config/oauth/Oauth2DetailsService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/config/oauth/Oauth2DetailsService.java
@@ -49,8 +49,9 @@ public class Oauth2DetailsService extends DefaultOAuth2UserService {
                     .password(password)
                     .email(email)
                     .name(name)
-                    .role(Role.ROLE_USER)
                     .build();
+
+            user.setRole(Role.ROLE_USER);
 
             return new PrincipalDetails(userRepository.save(user), oAuth2User.getAttributes());           // 리턴 -> 세션에 저장
         } else {                             // 페이스북으로 이미 회원가입이 되어있음

--- a/src/main/java/com/s1dmlgus/instagram02/domain/image/Image.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/image/Image.java
@@ -1,5 +1,6 @@
 package com.s1dmlgus.instagram02.domain.image;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 import java.util.UUID;
 
 @Builder
-@ToString
+@ToString(exclude = "user")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
@@ -26,11 +27,13 @@ public class Image extends BaseTimeEntity {
     private String postImageUrl;
 
 
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    @ManyToOne
     private User user;
 
 
+    //...
 
     // 좋아요
     // 댓글

--- a/src/main/java/com/s1dmlgus/instagram02/domain/image/ImageRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/image/ImageRepository.java
@@ -2,5 +2,10 @@ package com.s1dmlgus.instagram02.domain.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    List<Image> findAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -2,13 +2,15 @@ package com.s1dmlgus.instagram02.domain.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.web.dto.user.UserUpdateRequestDto;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.List;
 
-@Builder
-@ToString
+
+@ToString   // 연관관계 exclude
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -37,6 +39,14 @@ public class User extends BaseTimeEntity{
     @Enumerated(EnumType.STRING)
     private Role role;                  // 권한
 
+
+    @Builder
+    public User(String username, String password, String email, String name) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.name = name;
+    }
 
     // 비밀번호 암호화
     public void bcryptPw(String encode) {

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -7,10 +7,11 @@ import com.s1dmlgus.instagram02.web.dto.user.UserUpdateRequestDto;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 
 
-@ToString   // 연관관계 exclude
+@ToString(exclude = "images")
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
@@ -39,6 +40,9 @@ public class User extends BaseTimeEntity{
     @Enumerated(EnumType.STRING)
     private Role role;                  // 권한
 
+
+    @OneToMany(mappedBy = "user")
+    private List<Image> images = new ArrayList<Image>();
 
     @Builder
     public User(String username, String password, String email, String name) {

--- a/src/main/java/com/s1dmlgus/instagram02/handler/exception/CustomException.java
+++ b/src/main/java/com/s1dmlgus/instagram02/handler/exception/CustomException.java
@@ -1,0 +1,8 @@
+package com.s1dmlgus.instagram02.handler.exception;
+
+public class CustomException extends RuntimeException{
+
+    public CustomException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/s1dmlgus/instagram02/handler/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/s1dmlgus/instagram02/handler/exception/GlobalExceptionHandler.java
@@ -1,20 +1,18 @@
 package com.s1dmlgus.instagram02.handler.exception;
 
 
+
+import com.s1dmlgus.instagram02.utils.Script;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 
 @RestControllerAdvice
@@ -38,6 +36,14 @@ public class GlobalExceptionHandler {
         logger.info("Exception ! : {} ", e.toString(), e);
         return new ResponseEntity<>(new ResponseDto<>(e.getMessage(), null), HttpStatus.BAD_REQUEST);
     }
+
+    @ExceptionHandler(CustomException.class)
+    public String CustomException(CustomException e) {
+
+        logger.info("Exception ! : {} ", e.toString(), e);
+        return Script.back(e.getMessage());
+    }
+
 
     // 이미지 크기 예외처리
     @ExceptionHandler(FileSizeLimitExceededException.class)

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -44,7 +44,6 @@ public class UserService {
         // 2. 암호화
         bcryptPw(user);
         // 3. 권한 설정
-
         user.setRole(Role.ROLE_USER);
 
         // 4. 영속화
@@ -90,11 +89,9 @@ public class UserService {
         User user = userRepository.findById(id).orElseThrow(() -> {
             throw new CustomException("해당 유저가 없습니다");
         });
-        List<Image> imageList = imageRepository.findAllByUserId(id);
+        logger.info("user : {}", user);
 
-        logger.info("imageList : {}", imageList);
-
-        return new UserProfileResponseDto(user, imageList);
+        return new UserProfileResponseDto(user);
     }
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -1,24 +1,37 @@
 package com.s1dmlgus.instagram02.service;
 
+import com.s1dmlgus.instagram02.domain.image.Image;
+import com.s1dmlgus.instagram02.domain.image.ImageRepository;
 import com.s1dmlgus.instagram02.domain.user.Role;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
+import com.s1dmlgus.instagram02.handler.exception.CustomException;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.auth.JoinRequestDto;
 import com.s1dmlgus.instagram02.web.dto.auth.JoinResponseDto;
+import com.s1dmlgus.instagram02.web.dto.user.UserProfileResponseDto;
 import com.s1dmlgus.instagram02.web.dto.user.UserUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
+    private final ImageRepository imageRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    Logger logger = LoggerFactory.getLogger(UserService.class);
 
     // 회원가입
     @Transactional
@@ -71,4 +84,17 @@ public class UserService {
             throw new CustomApiException("현재 사용중인 닉네임입니다.");
         }
     }
+
+    public UserProfileResponseDto getProfile(Long id) {
+
+        User user = userRepository.findById(id).orElseThrow(() -> {
+            throw new CustomException("해당 유저가 없습니다");
+        });
+        List<Image> imageList = imageRepository.findAllByUserId(id);
+
+        logger.info("imageList : {}", imageList);
+
+        return new UserProfileResponseDto(user, imageList);
+    }
+
 }

--- a/src/main/java/com/s1dmlgus/instagram02/utils/Script.java
+++ b/src/main/java/com/s1dmlgus/instagram02/utils/Script.java
@@ -1,0 +1,13 @@
+package com.s1dmlgus.instagram02.utils;
+
+public class Script {
+
+    public static String back(String msg) {
+
+        return "<script>" +
+                "alert('" + msg + "');" +
+                "history.back();" +
+                "</script>";
+
+    }
+}

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/UserController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/UserController.java
@@ -2,6 +2,12 @@ package com.s1dmlgus.instagram02.web.controller;
 
 
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
+import com.s1dmlgus.instagram02.domain.user.User;
+import com.s1dmlgus.instagram02.service.UserService;
+import com.s1dmlgus.instagram02.web.dto.user.UserProfileResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,12 +17,24 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 
 @RequestMapping("/user")
+@RequiredArgsConstructor
 @Controller
 public class UserController {
 
-    @GetMapping("/{id}")
-    public String profile(@PathVariable int id) {
+    Logger logger = LoggerFactory.getLogger(UserController.class);
 
+    private final UserService userService;
+
+
+    @GetMapping("/{id}")
+    public String profile(@PathVariable Long id, Model model, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        UserProfileResponseDto profileDto = userService.getProfile(id);
+
+        logger.info("profileDto : {}", profileDto);
+
+        model.addAttribute("profileDto", profileDto);
+        //model.addAttribute("principal", principalDetails);
         return "user/profile";
     }
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
@@ -17,12 +17,12 @@ public class UserProfileResponseDto {
     private int imageCount;
 
 
-    public UserProfileResponseDto(User user, List<Image> imageList) {
+    public UserProfileResponseDto(User user) {
         this.userId = user.getId();
         this.username = user.getName();
         this.website = user.getWebsite();
-        this.images = imageList;
-        this.imageCount = imageList.size();
+        this.images = user.getImages();
+        this.imageCount = user.getImages().size();
 
     }
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
@@ -1,0 +1,29 @@
+package com.s1dmlgus.instagram02.web.dto.user;
+
+
+import com.s1dmlgus.instagram02.domain.image.Image;
+import com.s1dmlgus.instagram02.domain.user.User;
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class UserProfileResponseDto {
+
+    private Long userId;
+    private String username;
+    private String bio;
+    private String website;
+    private List<Image> images;
+    private int imageCount;
+
+
+    public UserProfileResponseDto(User user, List<Image> imageList) {
+        this.userId = user.getId();
+        this.username = user.getName();
+        this.website = user.getWebsite();
+        this.images = imageList;
+        this.imageCount = imageList.size();
+
+    }
+
+}

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -28,7 +28,7 @@
 		<!--유저정보 및 사진등록 구독하기-->
 		<div class="profile-right">
 			<div class="name-group">
-				<h2>TherePrograming</h2>
+				<h2 th:text="${profileDto.username}">gg</h2>
 
 				<button class="cta" onclick="location.href='/image/upload'">사진등록</button>
 				<button class="cta" onclick="toggleSubscribe(this)">구독하기</button>
@@ -39,15 +39,16 @@
 
 			<div class="subscribe">
 				<ul>
-					<li><a href=""> 게시물<span>3</span>
-					</a></li>
+					<li><a href=""> 게시물<span th:text="${profileDto.imageCount}">3</span></a></li>
 					<li><a href="javascript:subscribeInfoModalOpen();"> 구독정보<span>2</span>
 					</a></li>
 				</ul>
 			</div>
 			<div class="state">
-				<h4>자기 소개입니다.</h4>
-				<h4>https://github.com/codingspecialist</h4>
+				<h4 th:text="${#strings.equals(profileDto.bio, null)} ?  '자기 소개입니다' : ${profileDto.bio}"></h4>
+				<a th:href="${#strings.equals(profileDto.website, null)} ?  '' : ${profileDto.website}">
+					<div th:text="${#strings.equals(profileDto.website, null)} ?  '' : ${profileDto.website}"></div>
+				</a>
 			</div>
 		</div>
 		<!--유저정보 및 사진등록 구독하기-->
@@ -67,30 +68,12 @@
 				<!--아이템들-->
 
 
-				<div class="img-box">
-					<a href=""> <img src="/images/home.jpg" />
+				<div class="img-box" th:each="image : ${profileDto.images}" th:reversed>
+					<a href=""> <img th:src="|/upload/${image.postImageUrl}|" />
 					</a>
-					<div class="comment">
-						<a href="#" class=""> <i class="fas fa-heart"></i><span>0</span>
-						</a>
-					</div>
-				</div>
+<!--					<div class="comment"><a href="#" class=""> <i class="fas fa-heart"></i><span th:text="${image.likeCount}">2</span>-->
 
-				<div class="img-box">
-					<a href=""> <img src="/images/home.jpg" />
 					</a>
-					<div class="comment">
-						<a href="#" class=""> <i class="fas fa-heart"></i><span>0</span>
-						</a>
-					</div>
-				</div>
-
-				<div class="img-box">
-					<a href=""> <img src="/images/home.jpg" />
-					</a>
-					<div class="comment">
-						<a href="#" class=""> <i class="fas fa-heart"></i><span>0</span>
-						</a>
 					</div>
 				</div>
 

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
@@ -1,11 +1,16 @@
 package com.s1dmlgus.instagram02.service;
 
+import com.s1dmlgus.instagram02.domain.image.Image;
+import com.s1dmlgus.instagram02.domain.image.ImageRepository;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
+import com.s1dmlgus.instagram02.web.controller.UserController;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.auth.JoinRequestDto;
+import com.s1dmlgus.instagram02.web.dto.user.UserProfileResponseDto;
 import com.s1dmlgus.instagram02.web.dto.user.UserUpdateRequestDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,9 +18,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -28,11 +37,16 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UserServiceUnitTest {
 
+    Logger logger = LoggerFactory.getLogger(UserServiceUnitTest.class);
+
+
     @InjectMocks
     private UserService userService;
 
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private ImageRepository imageRepository;
 
     @Spy
     private BCryptPasswordEncoder bCryptPasswordEncoder;
@@ -104,6 +118,25 @@ class UserServiceUnitTest {
     }
 
     
+    @DisplayName("프로필정보 가져오기 테스트")
+    @Test
+    public void getProfileTest() throws Exception{
+        //given
+        Long userId = 1L;
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.ofNullable(createUser()));
+        when(imageRepository.findAllByUserId(any(Long.class))).thenReturn(createImages());
+
+
+        //when
+        UserProfileResponseDto profile = userService.getProfile(userId);
+        logger.info("profile : {}", profile);
+
+        //then
+        Assertions.assertThat(profile.getImages().get(0).getCaption()).isEqualTo("테스트이미지");
+
+    }
+    
+    
     // 회원정보수정 DTO
     private UserUpdateRequestDto createUpdateRequestDto() {
         return UserUpdateRequestDto.builder()
@@ -132,11 +165,26 @@ class UserServiceUnitTest {
     // 유저생성 Entity
     private User createUser() {
         return User.builder()
-                .username("t1dmlgus")
+                .username("test1Dmlgus")
                 .password("1234")
                 .email("dmlgus@gmail.com")
-                .name("이의현")
+                .name("테스트의현")
                 .build();
+    }
+
+
+    private List<Image> createImages(){
+
+        Image testImage = Image.builder()
+                .caption("테스트이미지")
+                .postImageUrl("테스트명.jpg")
+                .user(createUser())
+                .build();
+
+        List<Image> testImages = new ArrayList<>();
+        testImages.add(testImage);
+
+        return testImages;
     }
 
 }

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
@@ -1,11 +1,9 @@
 package com.s1dmlgus.instagram02.service;
 
 import com.s1dmlgus.instagram02.domain.image.Image;
-import com.s1dmlgus.instagram02.domain.image.ImageRepository;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
-import com.s1dmlgus.instagram02.web.controller.UserController;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.auth.JoinRequestDto;
 import com.s1dmlgus.instagram02.web.dto.user.UserProfileResponseDto;
@@ -22,9 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -39,14 +34,11 @@ class UserServiceUnitTest {
 
     Logger logger = LoggerFactory.getLogger(UserServiceUnitTest.class);
 
-
     @InjectMocks
     private UserService userService;
-
     @Mock
     private UserRepository userRepository;
-    @Mock
-    private ImageRepository imageRepository;
+
 
     @Spy
     private BCryptPasswordEncoder bCryptPasswordEncoder;
@@ -94,8 +86,7 @@ class UserServiceUnitTest {
 
         //when
         ResponseDto<?> join = userService.join(joindto);
-
-        System.out.println("join = " + join);
+        logger.info("join {} :", join);
 
         //then
         assertThat(join.getMessage()).isEqualTo("회원가입이 정상적으로 되었습니다.");
@@ -110,7 +101,7 @@ class UserServiceUnitTest {
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
 
         //when
-        ResponseDto<?> update = userService.update(1l, createUpdateRequestDto());
+        ResponseDto<?> update = userService.update(1L, createUpdateRequestDto());
         
         //then
         assertThat(update.getMessage()).isEqualTo("회원 수정이 완료되었습니다.");
@@ -123,9 +114,7 @@ class UserServiceUnitTest {
     public void getProfileTest() throws Exception{
         //given
         Long userId = 1L;
-        when(userRepository.findById(any(Long.class))).thenReturn(Optional.ofNullable(createUser()));
-        when(imageRepository.findAllByUserId(any(Long.class))).thenReturn(createImages());
-
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(createProfile()));
 
         //when
         UserProfileResponseDto profile = userService.getProfile(userId);
@@ -173,18 +162,19 @@ class UserServiceUnitTest {
     }
 
 
-    private List<Image> createImages(){
+    // 프로필dto 주입
+    private User createProfile(){
 
-        Image testImage = Image.builder()
+        User user = createUser();
+        Image image = Image.builder()
                 .caption("테스트이미지")
                 .postImageUrl("테스트명.jpg")
-                .user(createUser())
+                .user(user)
                 .build();
+        user.getImages().add(image);
 
-        List<Image> testImages = new ArrayList<>();
-        testImages.add(testImage);
+        return user;
 
-        return testImages;
     }
 
 }


### PR DESCRIPTION
### 이슈 번호
resolved: #38 

### 개요
유저 프로필 페이지 렌더링

### 작업 내용

UserController.java
- Model을 이용하여 프로필(profile.html) 페이지에 회원정보, 이미지 렌더링

UserService.java
- getProfile메소드를 호출하여 프로필페이지에 렌더링할 DTO(UserProfileResponseDto) 생성

UserProfileResponseDto.java
- 유저(세션)를 인수로 회원정보와 지연로딩된 이미지를 생성자를 통해 멤버변수에 주입한다.

WebMvcConfig.java
- profile.html 에서 이미지 렌더링 시 필요한 저장된 파일 위치가 yml에 저장되어 있는데, 이를 @Value를 통해 바인딩 한다.
- WebMvcConfigurer를 상속받은 config파일에 addResourceHandlers를 재정의 하며 @Value를 prefix 형태(/upload/**)로 만들어  호출 시 @Value 값을  가져온다.

CustomException
- Controller 에서 발생한 예외처리 핸들러
- 예외메시지를 Alert


### 테스트

- [x] UserServiceUnitTest.java

### 주의사항

- User, Image (1:N), 두 엔티티 모두 지연로딩 설정
- User와 Image 1:N 연관관계를 단방향 -> 양방향 연관관계로 리펙토링
- 양방향 연관관계를 형성하면서 UserProfileResponseDto 생성 시 User.getImage로 지연로딩하여 멤버변수 주입

- Repositofy save 사용하면서 순수한 객체까지 고려한 양방향 연관관계를 굳이 로직을 작성하지 않아도 해당 객체 호출 시 자동으로 저장되는 듯 하다.

- @ToString으로 인해 LazyLoading 안되는 이슈 해결
(https://www.notion.so/LazyLoading-86fe05d23898461a9844a370bdb67954)