### PR TITLE
feat: 이미지 S3 연동 및 리펙토링[ISSUE-43] 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	implementation 'org.mariadb.jdbc:mariadb-java-client'
 
+	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-aws-context
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-context', version: '2.2.2.RELEASE'
+
+
 
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
@@ -42,6 +46,9 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	//Spring Cloud AWS
+
 
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,6 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	//Spring Cloud AWS
-
-
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/s1dmlgus/instagram02/service/ImageService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/ImageService.java
@@ -4,9 +4,6 @@ package com.s1dmlgus.instagram02.service;
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
 import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.domain.image.ImageRepository;
-
-
-import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
@@ -30,8 +27,7 @@ public class ImageService {
     Logger logger = LoggerFactory.getLogger(ImageService.class);
 
     private final ImageRepository imageRepository;
-    private final UserRepository userRepository;
-
+    private final S3Service s3Service;
 
     @Value("${file.path}")
     private String uploadFolder;
@@ -39,21 +35,26 @@ public class ImageService {
 
     // 이미지 업로드
     @Transactional
-    public ResponseDto<?> upload(ImageUploadDto imageUploadDto, PrincipalDetails principalDetails) {
+    public ResponseDto<?> upload(ImageUploadDto imageUploadDto, PrincipalDetails principalDetails){
 
         // 파일 명
         String fileName = createFile(imageUploadDto);
+
         // 파일업로드
-        uploadFile(imageUploadDto, fileName);
+        //uploadFile(imageUploadDto, fileName);
+
+        // s3 파일 업로드
+        String s3FileName = s3Service.upload(imageUploadDto, fileName);
+
 
         // 영속화
-        Image afterUploadImage = imageRepository.save(imageUploadDto.toEntity(fileName, principalDetails.getUser()));
+        Image afterUploadImage = imageRepository.save(imageUploadDto.toEntity(s3FileName, principalDetails.getUser()));
         logger.info("[after 영속화] : {}", afterUploadImage);
 
         return new ResponseDto<>("이미지가 업로드 되었습니다.", afterUploadImage.getId());
     }
 
-    // 파일 생성
+    // 파일명
     protected String createFile(ImageUploadDto imageUploadDto) {
         
         // 파일 유효성검사

--- a/src/main/java/com/s1dmlgus/instagram02/service/ImageService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/ImageService.java
@@ -44,11 +44,11 @@ public class ImageService {
         //uploadFile(imageUploadDto, fileName);
 
         // s3 파일 업로드
-        String s3FileName = s3Service.upload(imageUploadDto, fileName);
+        s3Service.upload(imageUploadDto, fileName);
 
 
         // 영속화
-        Image afterUploadImage = imageRepository.save(imageUploadDto.toEntity(s3FileName, principalDetails.getUser()));
+        Image afterUploadImage = imageRepository.save(imageUploadDto.toEntity(fileName, principalDetails.getUser()));
         logger.info("[after 영속화] : {}", afterUploadImage);
 
         return new ResponseDto<>("이미지가 업로드 되었습니다.", afterUploadImage.getId());

--- a/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
@@ -19,6 +19,8 @@ import javax.annotation.PostConstruct;
 @Service
 public class S3Service {
 
+    public static final String CLOUD_FRONT_DOMAIN_NAME="d3r3itann8ixvx.cloudfront.net";
+
     private AmazonS3 s3Client;
 
     @Value("${cloud.aws.credentials.accessKey}")
@@ -58,7 +60,7 @@ public class S3Service {
             throw new CustomApiException("s3 이미지 업로드에 실패하였습니다.");
         }
 
-        return s3Client.getUrl(bucket, fileName).toString();
+        return fileName;
     }
 
 

--- a/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
@@ -11,11 +11,14 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
 import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
 
+@NoArgsConstructor
 @Service
 public class S3Service {
 
@@ -46,7 +49,8 @@ public class S3Service {
     }
 
     // s3 업로드
-    public String upload(ImageUploadDto imageUploadDto, String fileName){
+    @Transactional
+    public void upload(ImageUploadDto imageUploadDto, String fileName){
 
         try {
             ObjectMetadata objMeta = new ObjectMetadata();
@@ -59,8 +63,6 @@ public class S3Service {
             //e.printStackTrace();
             throw new CustomApiException("s3 이미지 업로드에 실패하였습니다.");
         }
-
-        return fileName;
     }
 
 

--- a/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
@@ -1,0 +1,66 @@
+package com.s1dmlgus.instagram02.service;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.IOUtils;
+import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
+import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+
+@Service
+public class S3Service {
+
+    private AmazonS3 s3Client;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @PostConstruct
+    public void setS3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
+
+        s3Client = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(this.region)
+                .build();
+    }
+
+    // s3 업로드
+    public String upload(ImageUploadDto imageUploadDto, String fileName){
+
+        try {
+            ObjectMetadata objMeta = new ObjectMetadata();
+            byte[] bytes = IOUtils.toByteArray(imageUploadDto.getFile().getInputStream());
+            objMeta.setContentLength(bytes.length);
+
+            s3Client.putObject(new PutObjectRequest(bucket, fileName, imageUploadDto.getFile().getInputStream(), objMeta)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (Exception e) {
+            //e.printStackTrace();
+            throw new CustomApiException("s3 이미지 업로드에 실패하였습니다.");
+        }
+
+        return s3Client.getUrl(bucket, fileName).toString();
+    }
+
+
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiController.java
@@ -16,7 +16,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/image/ImageUploadDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/image/ImageUploadDto.java
@@ -2,6 +2,7 @@ package com.s1dmlgus.instagram02.web.dto.image;
 
 import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.domain.user.User;
+import com.s1dmlgus.instagram02.service.S3Service;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -26,7 +27,7 @@ public class ImageUploadDto {
     public Image toEntity(String fileName, User user){
         return Image.builder()
                 .caption(caption)
-                .postImageUrl(fileName)
+                .postImageUrl("https://" + S3Service.CLOUD_FRONT_DOMAIN_NAME + "/" + fileName)
                 .user(user)
                 .build();
     }

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/image/ImageUploadDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/image/ImageUploadDto.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
-import java.util.Optional;
 
 
 @Builder
@@ -24,10 +23,10 @@ public class ImageUploadDto {
     private MultipartFile file;
 
 
-    public Image toEntity(String postImageUrl, User user){
+    public Image toEntity(String fileName, User user){
         return Image.builder()
                 .caption(caption)
-                .postImageUrl(postImageUrl)
+                .postImageUrl(fileName)
                 .user(user)
                 .build();
     }

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -69,7 +69,7 @@
 
 
 				<div class="img-box" th:each="image : ${profileDto.images}" th:reversed>
-					<a href=""> <img th:src="|/upload/${image.postImageUrl}|" />
+					<a href=""> <img th:src="${image.postImageUrl}" />
 					</a>
 <!--					<div class="comment"><a href="#" class=""> <i class="fas fa-heart"></i><span th:text="${image.likeCount}">2</span>-->
 

--- a/src/test/java/com/s1dmlgus/instagram02/service/ImageServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/ImageServiceUnitTest.java
@@ -2,15 +2,11 @@ package com.s1dmlgus.instagram02.service;
 
 
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
-import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.domain.image.ImageRepository;
 import com.s1dmlgus.instagram02.domain.user.User;
-import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
-
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,19 +15,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.Optional;
 
-
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
 
 @Transactional
@@ -42,6 +35,9 @@ class ImageServiceUnitTest {
     @Spy
     @InjectMocks
     private ImageService imageService;
+    @Mock
+    private S3Service s3Service;
+
     @Mock
     private ImageRepository imageRepository;
 
@@ -75,7 +71,7 @@ class ImageServiceUnitTest {
 
 
         when(imageService.createFile(imageUploadDto)).thenReturn("uuid_테스트명");
-        doNothing().when(imageService).uploadFile(any(), eq("uuid_테스트명"));
+        doNothing().when(s3Service).upload(any(), eq("uuid_테스트명"));
         when(imageRepository.save(any())).thenReturn(imageUploadDto.toEntity(eq("uuid_테스트명"),any()));
         
         //when
@@ -85,6 +81,7 @@ class ImageServiceUnitTest {
         assertThat(upload.getMessage()).isEqualTo("이미지가 업로드 되었습니다.");
         
     }
+
     
     @DisplayName("파일 생성 테스트")
     @Test

--- a/src/test/java/com/s1dmlgus/instagram02/service/S3ServiceTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/S3ServiceTest.java
@@ -1,0 +1,44 @@
+package com.s1dmlgus.instagram02.service;
+
+import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+
+    @InjectMocks
+    private S3Service s3Service;
+
+
+
+    @DisplayName("s3 업로드 실패 테스트")
+    @Test
+    public void failS3UploadTest() throws Exception{
+        //given
+        MockMultipartFile file = new MockMultipartFile("테스트파일", "테스트파일명.jpeg", "image/jpeg", "<<테스트파일>>".getBytes());
+        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", file);
+        String fileName = "uuid_테스트명";
+
+        //when
+
+        //then
+        assertThatThrownBy(() -> s3Service.upload(imageUploadDto, fileName))
+                .isInstanceOf(Exception.class)
+                .hasMessage("s3 이미지 업로드에 실패하였습니다.");
+
+
+    }
+
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,3 +34,15 @@ spring:
 
 file:
   path: C:/workspace/springbootwork/upload/
+
+cloud:
+  aws:
+    credentials:
+      accessKey: test
+      secretKey: test
+    s3:
+      bucket: s1dmlgus-instar03
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false


### PR DESCRIPTION
### 이슈 번호
resolved: #43 

### 개요

이미지 S3 연동 및 리펙토링


### 작업 내용

gradle

- spring-cloud-aws-context 의존성 추가

s3Service.java

- yml에 저장된 키와 버켓등을 @Value 값으로 가져온다.
- @PostConstruct 사용하여 의존성 주입이 이루어진 후, @Value로 가져온 정보를 토대로 aws s3 접근할 수 있는 s3Client를 초기화한다.
- s3Client의 putObject를 이용하여, 버켓, 파일명, 파일, 파일정보를 매개변수로 s3에 업로드한다.
- s3와 연동한 CloudFront를 사용하여 캐싱된 이미지를 바로 가져올 수 있도록 CloudFront 주소를 static 변수로 선언한다.

ImageSevice.java

- 로컬(C:/)에 업로드하는 메소드를 s3에 업로드하는 메소드로 교체한다.

ImageUploadDto.java

- 이미지 접근 시 S3가 아닌, CloudFront를 통해 접근할 수 있도록 DB postImageUrl를 리펙토링 한다. 

profile.html

- 이미지 렌더링 시 사용했던 WebMvcConfig의 "/upload/**" prefix를 없앤다.



### 테스트

- [x] ImageServiceUnitTest.java
- [x] S3SeviceTest.java
 

### 주의사항

- 객체지향으로 코드로 작성하여, 이미지 업로드 시 구현된 기능으로 교체할 수 있었던 것이 인상적이였다.


- [s3 이미지 업로드 트러블 슈팅](https://www.notion.so/S3-11f63777ac794683b8bbe739016bd428)



