### PR TITLE
refactor: 유저 프로필 페이지 렌더링 [ISSUE-38] 

### DIFF
--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.s1dmlgus.instagram02.domain.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
 import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.web.dto.user.UserUpdateRequestDto;
@@ -40,7 +41,7 @@ public class User extends BaseTimeEntity{
     @Enumerated(EnumType.STRING)
     private Role role;                  // 권한
 
-
+    @JsonIgnoreProperties({"user"})
     @OneToMany(mappedBy = "user")
     private List<Image> images = new ArrayList<Image>();
 
@@ -51,6 +52,16 @@ public class User extends BaseTimeEntity{
         this.email = email;
         this.name = name;
     }
+
+    @Builder
+    public void testUser(String username, String password, String email, String name) {
+        this.id = 1L;
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.name = name;
+    }
+
 
     // 비밀번호 암호화
     public void bcryptPw(String encode) {
@@ -75,9 +86,9 @@ public class User extends BaseTimeEntity{
     public void updateUserProfile(UserUpdateRequestDto updateRequestDto) {
 
         this.name = updateRequestDto.getName();
+        this.bio = updateRequestDto.getBio();
         this.website = updateRequestDto.getWebsite();
         this.phone = updateRequestDto.getPhone();
-        this.bio = updateRequestDto.getBio();
 
         if (updateRequestDto.getGender().equals("남") || updateRequestDto.getGender().equals("")) {
             this.gender = Gender.MAN;

--- a/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/user/User.java
@@ -53,7 +53,7 @@ public class User extends BaseTimeEntity{
         this.name = name;
     }
 
-    @Builder
+
     public void testUser(String username, String password, String email, String name) {
         this.id = 1L;
         this.username = username;

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -77,14 +77,14 @@ public class UserService {
         }
     }
 
-    public UserProfileResponseDto getProfile(Long id) {
+    public UserProfileResponseDto getProfile(Long id, Long sessionId) {
 
         User user = userRepository.findById(id).orElseThrow(() -> {
             throw new CustomException("해당 유저가 없습니다");
         });
         logger.info("user : {}", user);
 
-        return new UserProfileResponseDto(user);
+        return new UserProfileResponseDto(user, sessionId);
     }
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/UserController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/UserController.java
@@ -2,7 +2,6 @@ package com.s1dmlgus.instagram02.web.controller;
 
 
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
-import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.service.UserService;
 import com.s1dmlgus.instagram02.web.dto.user.UserProfileResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,7 @@ public class UserController {
     @GetMapping("/{id}")
     public String profile(@PathVariable Long id, Model model, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        UserProfileResponseDto profileDto = userService.getProfile(id);
+        UserProfileResponseDto profileDto = userService.getProfile(id, principalDetails.getUser().getId());
 
         logger.info("profileDto : {}", profileDto);
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
@@ -15,14 +15,21 @@ public class UserProfileResponseDto {
     private String website;
     private List<Image> images;
     private int imageCount;
+    private boolean pageOwnerState;
 
 
-    public UserProfileResponseDto(User user) {
+    public UserProfileResponseDto(User user, Long sessionId) {
         this.userId = user.getId();
         this.username = user.getName();
+        this.bio = user.getBio();
         this.website = user.getWebsite();
         this.images = user.getImages();
         this.imageCount = user.getImages().size();
+
+        if (userId.equals(sessionId)) {
+            pageOwnerState = true;
+        }
+
 
     }
 

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -31,6 +31,10 @@
             <a href="/" class="logo">
                 <img src="/images/logo.jpg" alt="">
             </a>
+
+            <!-- 세션유저 js 활용-->
+<!--            <input type="hidden" id = "t1" var="tt" sec:authentication="principal.user.name">-->
+
             <!-- nav -->
             <nav class="navi">
                 <ul class="navi-list">

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -30,8 +30,9 @@
 			<div class="name-group">
 				<h2 th:text="${profileDto.username}">gg</h2>
 
-				<button class="cta" onclick="location.href='/image/upload'">사진등록</button>
-				<button class="cta" onclick="toggleSubscribe(this)">구독하기</button>
+
+				<button th:if="${profileDto.pageOwnerState}" class="cta" onclick="location.href='/image/upload'">사진등록</button>
+				<button th:if="${!profileDto.pageOwnerState}" class="cta" onclick="toggleSubscribe(this)">구독하기</button>
 				<button class="modi" onclick="popup('.modal-info')">
 					<i class="fas fa-cog"></i>
 				</button>
@@ -45,7 +46,7 @@
 				</ul>
 			</div>
 			<div class="state">
-				<h4 th:text="${#strings.equals(profileDto.bio, null)} ?  '자기 소개입니다' : ${profileDto.bio}"></h4>
+				<span th:text="${#strings.equals(profileDto.bio, null)} ?  '' : ${profileDto.bio}"></span>
 				<a th:href="${#strings.equals(profileDto.website, null)} ?  '' : ${profileDto.website}">
 					<div th:text="${#strings.equals(profileDto.website, null)} ?  '' : ${profileDto.website}"></div>
 				</a>

--- a/src/main/resources/templates/user/update.html
+++ b/src/main/resources/templates/user/update.html
@@ -49,7 +49,7 @@
 			<div class="content-item__06">
 				<div class="item__title">소개</div>
 				<div class="item__input">
-					<textarea name="bio" id="" rows="3" th:value="${principal.bio}"></textarea>
+					<textarea name="bio" rows="3" th:text="${principal.bio}"></textarea>
 				</div>
 			</div>
 			<div class="content-item__07">

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
@@ -47,8 +47,8 @@ class UserServiceUnitTest {
     @Test
     public void duplicateUsernameTest() throws Exception {
         //given
-        User user1 = createUser();
-        User user2 = createUser();
+        User user1 = testUser();
+        User user2 = testUser();
         when(userRepository.existsByUsername(user1.getUsername())).thenReturn(true);
 
         //when
@@ -65,7 +65,7 @@ class UserServiceUnitTest {
     @Test
     public void bcryptPwTest() throws Exception {
         //given
-        User user = createUser();
+        User user = testUser();
 
         //when
         userService.bcryptPw(user);
@@ -117,7 +117,7 @@ class UserServiceUnitTest {
         when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(createProfile()));
 
         //when
-        UserProfileResponseDto profile = userService.getProfile(userId);
+        UserProfileResponseDto profile = userService.getProfile(userId, 1L);
         logger.info("profile : {}", profile);
 
         //then
@@ -152,28 +152,28 @@ class UserServiceUnitTest {
 
 
     // 유저생성 Entity
-    private User createUser() {
-        return User.builder()
-                .username("test1Dmlgus")
-                .password("1234")
-                .email("dmlgus@gmail.com")
-                .name("테스트의현")
-                .build();
+    private User testUser() {
+
+        User user = new User();
+        user.testUser("test1Dmlgus", "1234", "dmlgus@gmail.com", "테스트의현");
+
+        return user;
     }
+
 
 
     // 프로필dto 주입
     private User createProfile(){
 
-        User user = createUser();
+        User testUser = testUser();
         Image image = Image.builder()
                 .caption("테스트이미지")
                 .postImageUrl("테스트명.jpg")
-                .user(user)
+                .user(testUser)
                 .build();
-        user.getImages().add(image);
+        testUser.getImages().add(image);
 
-        return user;
+        return testUser;
 
     }
 


### PR DESCRIPTION
### 이슈 번호
resolved: #38 

### 개요

유저 프로필 페이지 렌더링
- 프로필 페이지 접근 시 해당 유저의 프로필이면 사진추가 버튼 활성화
- 다른 유저 페이지 접근 시 구독하기 버튼 활성화

### 작업 내용

UserProfileResponseDto.java

- 세션 아이디와 비교해서 pageOwnerState 변수로 프로필 페이지 구분

User.java

- 테스트 유저 추가 


### 테스트

- [x] UserServiceUnitTest.java 

### 주의사항

- header.html 에서 springSecurity 세션을 이용해서 thyemeleaf로 해당 유저 프로필 페이지로 href 태그를 작성하고자 했는데 방법을 찾지 못했다.
- 위 방법을 찾지 못하면, 컨트롤러에서 세션유저(@AuthenticationPrincipal)을 이용하여 model.addAttribute 해야할 거 같다.
- model.addAttribute를 사용하면 header가 공통 레이아웃이기 때문에 모든 컨트롤러에 model.addAttribute 를 추가해야한다.

