### PR TITLE
feat: 구독하기 구현[ISSUE-32]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,8 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-aws-context
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-context', version: '2.2.2.RELEASE'
 
-
+	// QLRM(Query Language Result Mapper)
+	implementation group: 'ch.simas.qlrm', name: 'qlrm', version: '1.7.1'
 
 	asciidoctorExtensions 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 

--- a/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/Subscribe.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/Subscribe.java
@@ -1,6 +1,36 @@
 package com.s1dmlgus.instagram02.domain.subscribe;
 
 import com.s1dmlgus.instagram02.domain.BaseTimeEntity;
+import com.s1dmlgus.instagram02.domain.user.User;
+import lombok.*;
 
+import javax.persistence.*;
+
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "subscribe_uk",
+                        columnNames = {"to_user_id", "from_user_id"}
+                )
+        }
+)
+@Entity
 public class Subscribe extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User toUser;
+
+    @ManyToOne
+    private User fromUser;
+
+
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/SubscribeRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/SubscribeRepository.java
@@ -12,9 +12,17 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
     void subscribe(@Param("fromUserId") Long fromUserId, @Param("toUserId") Long toUserId);
 
     @Modifying
-    @Query(value = "DELETE FROM subscribe WHERE from_user_id = :fromUserId AND to_user_id = :toUserId)", nativeQuery = true)
+    @Query(value = "DELETE FROM subscribe WHERE from_user_id = :fromUserId AND to_user_id = :toUserId", nativeQuery = true)
     void unSubscribe(@Param("fromUserId") Long fromUserId, @Param("toUserId") Long toUserId);
 
+
+    // 구독 상태
+    @Query(value = "SELECT COUNT(*) FROM subscribe where from_user_id = :principalId and to_user_id = :pageId", nativeQuery = true)
+    int mSubscribeState(@Param("pageId") Long pageId, @Param("principalId") Long principalId);
+
+    // 구독자 수
+    @Query(value = "SELECT COUNT(*) FROM subscribe where to_user_id = :pageId", nativeQuery = true)
+    int mSubscribeCount(@Param("pageId") Long pageId);
 
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/SubscribeRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/SubscribeRepository.java
@@ -1,0 +1,7 @@
+package com.s1dmlgus.instagram02.domain.subscribe;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/SubscribeRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/subscribe/SubscribeRepository.java
@@ -1,7 +1,20 @@
 package com.s1dmlgus.instagram02.domain.subscribe;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+
+    @Modifying
+    @Query(value = "INSERT INTO subscribe(from_user_id, to_user_id, created_date) VALUES(:fromUserId, :toUserId, now())", nativeQuery = true)
+    void subscribe(@Param("fromUserId") Long fromUserId, @Param("toUserId") Long toUserId);
+
+    @Modifying
+    @Query(value = "DELETE FROM subscribe WHERE from_user_id = :fromUserId AND to_user_id = :toUserId)", nativeQuery = true)
+    void unSubscribe(@Param("fromUserId") Long fromUserId, @Param("toUserId") Long toUserId);
+
+
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
@@ -4,15 +4,23 @@ package com.s1dmlgus.instagram02.service;
 import com.s1dmlgus.instagram02.domain.subscribe.SubscribeRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
+import com.s1dmlgus.instagram02.web.dto.subscribe.SubscribeDto;
 import lombok.RequiredArgsConstructor;
+import org.qlrm.mapper.JpaResultMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class SubscribeService {
 
     private final SubscribeRepository subscribeRepository;
+    private final EntityManager em;
+
 
     // 구독하기
     @Transactional
@@ -40,6 +48,31 @@ public class SubscribeService {
         return new ResponseDto<>("구독 취소하였습니다.", subscribeCount);
     }
 
+    // 구독 유저 조회
+    @Transactional(readOnly = true)
+    public List<SubscribeDto> subscribeList(Long principalId, Long pageId) {
+
+        // 쿼리 준비
+        String sb = "SELECT u.id, u.username, u.profile_Image_Url, " +
+                "if((SELECT true FROM subscribe WHERE from_User_id = ? AND to_User_id = u.id), 1, 0) follow, " +
+                "if((?=u.id), 1, 0) iam " +
+                "FROM user u INNER JOIN subscribe s " +
+                "ON u.id = s.from_User_id " +
+                "WHERE s.to_User_id = ? ";
+
+        // 1. 물음표 principalId
+        // 2. 물음표 principalId
+        // 3. 물음표 pageUserId
+
+        // 쿼리 완성
+        Query nativeQuery = em.createNativeQuery(sb)
+                .setParameter(1, principalId)
+                .setParameter(2, principalId)
+                .setParameter(3, pageId);
 
 
+        // qlrm 라이브러리 -> dto에 DB결과를 매핑하기 위해
+        JpaResultMapper result = new JpaResultMapper();
+        return result.list(nativeQuery, SubscribeDto.class);
+    }
 }

--- a/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
@@ -73,6 +73,25 @@ public class SubscribeService {
 
         // qlrm 라이브러리 -> dto에 DB결과를 매핑하기 위해
         JpaResultMapper result = new JpaResultMapper();
-        return result.list(nativeQuery, SubscribeDto.class);
+        List<SubscribeDto> list =result.list(nativeQuery, SubscribeDto.class);
+
+        return list;
     }
+
+
+    // 구독 상태 확인
+    @Transactional(readOnly = true)
+    public boolean getSubscribeState(Long pageId, Long sessionId) {
+
+        return  subscribeRepository.mSubscribeState(pageId, sessionId) == 1;
+    }
+
+    // 구독자 수 카운트
+    @Transactional(readOnly = true)
+    public int getSubscribeCount(Long pageId) {
+
+        return subscribeRepository.mSubscribeCount(pageId);
+    }
+
+
 }

--- a/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
@@ -1,0 +1,41 @@
+package com.s1dmlgus.instagram02.service;
+
+
+import com.s1dmlgus.instagram02.domain.subscribe.SubscribeRepository;
+import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
+import com.s1dmlgus.instagram02.web.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class SubscribeService {
+
+    private final SubscribeRepository subscribeRepository;
+
+    // 구독하기
+    @Transactional
+    public ResponseDto<?> subscribe(Long fromUserId, Long toUserId){
+
+        try {
+            subscribeRepository.subscribe(fromUserId, toUserId);
+        } catch (Exception e) {
+            throw new CustomApiException("이미 구독한 상태입니다.");
+        }
+
+        return new ResponseDto<>("구독하였습니다.", null);
+    }
+
+    // 구독 취소하기
+    @Transactional
+    public ResponseDto<?> unSubscribe(Long fromUserId, Long toUserId){
+
+        subscribeRepository.unSubscribe(fromUserId, toUserId);
+
+        return new ResponseDto<>("구독 취소하였습니다.", null);
+    }
+
+
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/SubscribeService.java
@@ -18,13 +18,16 @@ public class SubscribeService {
     @Transactional
     public ResponseDto<?> subscribe(Long fromUserId, Long toUserId){
 
+        int subscribeCount = 0;
+
         try {
             subscribeRepository.subscribe(fromUserId, toUserId);
+            subscribeCount= subscribeRepository.mSubscribeCount(toUserId);
         } catch (Exception e) {
             throw new CustomApiException("이미 구독한 상태입니다.");
         }
 
-        return new ResponseDto<>("구독하였습니다.", null);
+        return new ResponseDto<>("구독하였습니다.", subscribeCount);
     }
 
     // 구독 취소하기
@@ -32,8 +35,9 @@ public class SubscribeService {
     public ResponseDto<?> unSubscribe(Long fromUserId, Long toUserId){
 
         subscribeRepository.unSubscribe(fromUserId, toUserId);
+        int subscribeCount = subscribeRepository.mSubscribeCount(toUserId);
 
-        return new ResponseDto<>("구독 취소하였습니다.", null);
+        return new ResponseDto<>("구독 취소하였습니다.", subscribeCount);
     }
 
 

--- a/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/UserService.java
@@ -1,6 +1,5 @@
 package com.s1dmlgus.instagram02.service;
 
-import com.s1dmlgus.instagram02.domain.subscribe.SubscribeRepository;
 import com.s1dmlgus.instagram02.domain.user.Role;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
@@ -23,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final SubscribeRepository subscribeRepository;
+    private final SubscribeService subscribeService;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     Logger logger = LoggerFactory.getLogger(UserService.class);
@@ -88,9 +87,9 @@ public class UserService {
         });
         logger.info("user : {}", user);
 
-        boolean subscribeState = getSubscribeState(pageId, sessionId);
         boolean pageOwnerState = getPageOwnerState(pageId, sessionId);
-        int subscribeCount = getSubscribeCount(pageId);
+        boolean subscribeState = subscribeService.getSubscribeState(pageId, sessionId);
+        int subscribeCount = subscribeService.getSubscribeCount(pageId);
 
 
         return new UserProfileResponseDto(user, pageOwnerState, subscribeState, subscribeCount);
@@ -102,17 +101,6 @@ public class UserService {
         return pageid.equals(sessionId);
     }
 
-    // 구독 상태 확인
-    protected boolean getSubscribeState(Long pageId, Long sessionId) {
-
-        return  subscribeRepository.mSubscribeState(pageId, sessionId) == 1;
-    }
-
-    // 구독자 수 카운트
-    protected int getSubscribeCount(Long pageId) {
-
-        return subscribeRepository.mSubscribeCount(pageId);
-    }
 
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/api/SubscribeApiController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/api/SubscribeApiController.java
@@ -32,7 +32,6 @@ public class SubscribeApiController {
 
         ResponseDto<?> unSubscribe = subscribeService.unSubscribe(principalDetails.getUser().getId(), toUserId);
 
-
         return new ResponseEntity<>(unSubscribe, HttpStatus.OK);
     }
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/api/SubscribeApiController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/api/SubscribeApiController.java
@@ -4,11 +4,15 @@ package com.s1dmlgus.instagram02.web.controller.api;
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
 import com.s1dmlgus.instagram02.service.SubscribeService;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
+import com.s1dmlgus.instagram02.web.dto.subscribe.SubscribeDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -34,5 +38,16 @@ public class SubscribeApiController {
 
         return new ResponseEntity<>(unSubscribe, HttpStatus.OK);
     }
+
+    // 구독 유저 조회하기
+    @GetMapping("/api/subscribe/{pageId}")
+    public ResponseEntity<?> subscribe(@PathVariable Long pageId, @AuthenticationPrincipal PrincipalDetails principalDetails, Model model) {
+
+        List<SubscribeDto> subscribeDtos = subscribeService.subscribeList(principalDetails.getUser().getId(), pageId);
+
+        return new ResponseEntity<>(subscribeDtos, HttpStatus.OK);
+
+    }
+
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/api/SubscribeApiController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/api/SubscribeApiController.java
@@ -1,0 +1,39 @@
+package com.s1dmlgus.instagram02.web.controller.api;
+
+
+import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
+import com.s1dmlgus.instagram02.service.SubscribeService;
+import com.s1dmlgus.instagram02.web.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RequiredArgsConstructor
+@RestController
+public class SubscribeApiController {
+
+    private final SubscribeService subscribeService;
+
+    // 구독하기
+    @PostMapping("/api/subscribe/{toUserId}")
+    public ResponseEntity<?> subscribe(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long toUserId) {
+
+        ResponseDto<?> subscribe = subscribeService.subscribe(principalDetails.getUser().getId(), toUserId);
+
+        return new ResponseEntity<>(subscribe, HttpStatus.OK);
+    }
+
+    // 구독 취소하기
+    @DeleteMapping("/api/subscribe/{toUserId}")
+    public ResponseEntity<?> unSubscribe(@AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable Long toUserId){
+
+        ResponseDto<?> unSubscribe = subscribeService.unSubscribe(principalDetails.getUser().getId(), toUserId);
+
+
+        return new ResponseEntity<>(unSubscribe, HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/subscribe/SubscribeDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/subscribe/SubscribeDto.java
@@ -1,0 +1,19 @@
+package com.s1dmlgus.instagram02.web.dto.subscribe;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.math.BigInteger;
+
+@AllArgsConstructor
+@Data
+public class SubscribeDto {
+
+    private BigInteger id;
+    private String username;
+    private String profileImageUrl;
+    private Integer follow;
+    private Integer iam;
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/user/UserProfileResponseDto.java
@@ -15,21 +15,23 @@ public class UserProfileResponseDto {
     private String website;
     private List<Image> images;
     private int imageCount;
+
     private boolean pageOwnerState;
+    private boolean subscribeState;         // 구독 상태
+    private int subscribeCount;             // 구독자 수
 
 
-    public UserProfileResponseDto(User user, Long sessionId) {
+
+    public UserProfileResponseDto(User user, boolean pageOwnerState, boolean subscribeState, int subscribeCount) {
         this.userId = user.getId();
         this.username = user.getName();
         this.bio = user.getBio();
         this.website = user.getWebsite();
         this.images = user.getImages();
         this.imageCount = user.getImages().size();
-
-        if (userId.equals(sessionId)) {
-            pageOwnerState = true;
-        }
-
+        this.pageOwnerState = pageOwnerState;
+        this.subscribeState = subscribeState;
+        this.subscribeCount = subscribeCount;
 
     }
 

--- a/src/main/resources/static/js/profile.js
+++ b/src/main/resources/static/js/profile.js
@@ -11,15 +11,54 @@
  */
 
 // (1) 유저 프로파일 페이지 구독하기, 구독취소
-function toggleSubscribe(obj) {
-	if ($(obj).text() === "구독취소") {
-		$(obj).text("구독하기");
-		$(obj).toggleClass("blue");
+function toggleSubscribe(toUserId, obj) {
+
+
+    console.log($(obj).text());
+
+
+
+	if ($(obj).text() == "구독취소") {
+
+	    $.ajax({
+            type:'delete',
+            url:"/api/subscribe/" +toUserId,
+            dataType:"json"
+
+	    }).done(res=>{
+            $(obj).text("구독하기");
+        	$(obj).toggleClass("blue");
+        	console.log(res);
+        	$('#subscribeCount').html(res.data);
+        	//$('#btn-heart').val(aa.data.likeId);    // 좋아요 번호
+
+	    }).fail(error=>{
+            console.log("구독취소 실패", error);
+	    });
+
 	} else {
-		$(obj).text("구독취소");
-		$(obj).toggleClass("blue");
+
+        $.ajax({
+                type:'post',
+                url:"/api/subscribe/" +toUserId,
+                dataType:"json"
+
+            }).done(res=>{
+                $(obj).text("구독취소");
+                $(obj).toggleClass("blue");
+                console.log(res);
+                $('#subscribeCount').html(res.data);
+
+            }).fail(error=>{
+                console.log("구독하기 실패", error);
+            });
 	}
 }
+
+
+
+
+
 
 // (2) 구독자 정보  모달 보기
 function subscribeInfoModalOpen() {

--- a/src/main/resources/static/js/profile.js
+++ b/src/main/resources/static/js/profile.js
@@ -13,10 +13,7 @@
 // (1) 유저 프로파일 페이지 구독하기, 구독취소
 function toggleSubscribe(toUserId, obj) {
 
-
     console.log($(obj).text());
-
-
 
 	if ($(obj).text() == "구독취소") {
 
@@ -30,7 +27,7 @@ function toggleSubscribe(toUserId, obj) {
         	$(obj).toggleClass("blue");
         	console.log(res);
         	$('#subscribeCount').html(res.data);
-        	//$('#btn-heart').val(aa.data.likeId);    // 좋아요 번호
+
 
 	    }).fail(error=>{
             console.log("구독취소 실패", error);
@@ -57,17 +54,63 @@ function toggleSubscribe(toUserId, obj) {
 
 
 
-
-
-
 // (2) 구독자 정보  모달 보기
 function subscribeInfoModalOpen() {
+
+    var pageId = $("#userId").val();
 	$(".modal-subscribe").css("display", "flex");
+
+    $.ajax({
+         type:'get',
+         url:"/api/subscribe/"+pageId,
+         dataType:"json"
+
+     }).done(res=>{
+          console.log(res);
+
+          res.forEach((u)=>{
+               let item = getSubscribeModalItem(u);
+               $("#subscribeModalList").append(item);
+
+           })
+    }).fail(error=>{
+          console.log("구독정보 불러오기 예외",error);
+
+    });
+
+
 }
 
-function getSubscribeModalItem() {
+function getSubscribeModalItem(u) {
+
+    let item=`
+        <div class="subscribe__item"  id="subscribeModalItem-${u.id}">
+            <div class="subscribe__img">
+                <img src="/upload/${u.profileImageUrl}" onerror="this.src='/images/person.jpeg'"/>
+            </div>
+            <div class="subscribe__text">
+                <h2>${u.username}</h2>
+            </div>
+            <div class="subscribe__btn">`;
+
+            if(!u.iam){      // 동일 유저가 아닐 때, 버튼이 만들어져야 한다.
+                if(u.follow){   // 구독한 상태
+                        item += `<button class="cta blue" onclick="toggleSubscribe(${u.id}, this)">구독취소</button>`;
+                }else{                       // 구독안한 상태
+                        item +=`<button class="cta" onclick="toggleSubscribe(${u.id}, this)">구독하기</button>`;
+                }
+            }
+             item +=`
+            </div>
+        </div>`;
+
+    return item;
 
 }
+
+
+
+
 
 
 // (3) 구독자 정보 모달에서 구독하기, 구독취소

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -50,7 +50,8 @@
 			<div class="subscribe">
 				<ul>
 					<li><a href=""> 게시물<span th:text="${profileDto.imageCount}">3</span></a></li>
-					<li><a href="javascript:subscribeInfoModalOpen();"> 구독정보<span id="subscribeCount" th:text="${profileDto.subscribeCount}">0</span>
+					<li><a href="javascript:subscribeInfoModalOpen();"> 팔로워<span id="subscribeCount" th:text="${profileDto.subscribeCount}">0</span>
+<!--					<li><a href="javascript:subscribeInfoModalOpen();"> 팔로잉<span id="subscribeCount" th:text="${profileDto.subscribeCount}">0</span>-->
 					</a></li>
 				</ul>
 			</div>
@@ -101,9 +102,9 @@
 		<button onclick="closePopup('.modal-info')">취소</button>
 	</div>
 </div>
-<!--로그아웃, 회원정보변경 모달 end-->
+<!-- 로그아웃, 회원정보변경 모달 end -->
 
-<!--프로필사진 바꾸기 모달-->
+<!-- 프로필사진 바꾸기 모달-->
 <div class="modal-image" onclick="modalImage()">
 	<div class="modal">
 		<p>프로필 사진 바꾸기</p>
@@ -112,8 +113,12 @@
 	</div>
 </div>
 
-<!--프로필사진 바꾸기 모달end-->
+<!-- 프로필사진 바꾸기 모달 end-->
 
+<input type="hidden" id="userId" th:value="${profileDto.userId}">
+
+
+<!-- 구독정보 모달 -->
 <div class="modal-subscribe">
 	<div class="subscribe">
 		<div class="subscribe-header">
@@ -125,34 +130,14 @@
 
 		<div class="subscribe-list" id="subscribeModalList">
 
-			<div class="subscribe__item" id="subscribeModalItem-1">
-				<div class="subscribe__img">
-					<img src="#" onerror="this.src='/images/person.jpeg'"/>
-				</div>
-				<div class="subscribe__text">
-					<h2>love</h2>
-				</div>
-				<div class="subscribe__btn">
-					<button class="cta blue" onclick="toggleSubscribeModal(this)">구독취소</button>
-				</div>
-			</div>
+			<!-- 아이템 -->
 
 
-			<div class="subscribe__item" id="subscribeModalItem-2">
-				<div class="subscribe__img">
-					<img src="#" onerror="this.src='/images/person.jpeg'"/>
-				</div>
-				<div class="subscribe__text">
-					<h2>ssar</h2>
-				</div>
-				<div class="subscribe__btn">
-					<button class="cta blue" onclick="toggleSubscribeModal(this)">구독취소</button>
-				</div>
-			</div>
 		</div>
 	</div>
 
 </div>
+<!-- 구독정보 모달 end-->
 
 
 <script src="/js/profile.js"></script>

--- a/src/main/resources/templates/user/profile.html
+++ b/src/main/resources/templates/user/profile.html
@@ -30,9 +30,18 @@
 			<div class="name-group">
 				<h2 th:text="${profileDto.username}">gg</h2>
 
+				<div th:if="${profileDto.pageOwnerState}">
+					<button class="cta" onclick="location.href='/image/upload'">사진등록</button>
+				</div>
+				<div th:unless="${profileDto.pageOwnerState}">
+					<div th:if="${profileDto.subscribeState}">
+						<button class="cta blue" th:onclick="|toggleSubscribe(${profileDto.userId}, this)|">구독취소</button>
+					</div>
+					<div th:unless="${profileDto.subscribeState}">
+						<button class="cta" th:onclick="|toggleSubscribe(${profileDto.userId}, this)|">구독하기</button>
+					</div>
+				</div>
 
-				<button th:if="${profileDto.pageOwnerState}" class="cta" onclick="location.href='/image/upload'">사진등록</button>
-				<button th:if="${!profileDto.pageOwnerState}" class="cta" onclick="toggleSubscribe(this)">구독하기</button>
 				<button class="modi" onclick="popup('.modal-info')">
 					<i class="fas fa-cog"></i>
 				</button>
@@ -41,7 +50,7 @@
 			<div class="subscribe">
 				<ul>
 					<li><a href=""> 게시물<span th:text="${profileDto.imageCount}">3</span></a></li>
-					<li><a href="javascript:subscribeInfoModalOpen();"> 구독정보<span>2</span>
+					<li><a href="javascript:subscribeInfoModalOpen();"> 구독정보<span id="subscribeCount" th:text="${profileDto.subscribeCount}">0</span>
 					</a></li>
 				</ul>
 			</div>

--- a/src/test/java/com/s1dmlgus/instagram02/service/SubscribeServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/SubscribeServiceUnitTest.java
@@ -1,43 +1,151 @@
 package com.s1dmlgus.instagram02.service;
 
+import com.s1dmlgus.instagram02.domain.subscribe.SubscribeRepository;
+import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.subscribe.SubscribeDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 
 
 @Transactional
-//@ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class SubscribeServiceUnitTest {
 
-    @Autowired
+
+    @InjectMocks
     private SubscribeService subscribeService;
 
-//    @Spy
-//    private EntityManager em;
-//    @Mock
-//    private JpaResultMapper jpaResultMapper;
-//
-    @DisplayName("구독자 리스트 테스트")
+    @Mock
+    private SubscribeRepository subscribeRepository;
+    @Mock
+    private EntityManager em;
+
+    private Long sessionUserId;
+    private Long pageUserId;
+
+    @BeforeEach
+    public void setUp(){
+        sessionUserId = 1L;
+        pageUserId = 2L;
+    }
+
+
+
+
+    @DisplayName("구독하기 테스트")
+    @Test
+    public void subscribeTest() throws Exception{
+        //given
+
+
+        doNothing().when(subscribeRepository).subscribe(anyLong(), anyLong());
+        when(subscribeRepository.mSubscribeCount(pageUserId)).thenReturn(1);
+
+
+        //when
+        ResponseDto<?> subscribe = subscribeService.subscribe(sessionUserId, pageUserId);
+
+        //then
+        assertThat(subscribe.getMessage()).isEqualTo("구독하였습니다.");
+    }
+
+    
+    @DisplayName("구독취소 테스트")
+    @Test
+    public void unSuscribeTest() throws Exception{
+        //given
+
+        doNothing().when(subscribeRepository).unSubscribe(anyLong(), anyLong());
+        when(subscribeRepository.mSubscribeCount(pageUserId)).thenReturn(1);
+
+
+        //when
+        ResponseDto<?> unSubscribe = subscribeService.unSubscribe(sessionUserId, pageUserId);
+
+
+        //then
+        assertThat(unSubscribe.getMessage()).isEqualTo("구독 취소하였습니다.");
+
+
+    }
+
+    @DisplayName("구독자 리스트 가져오기 테스트")
     @Test
     public void subscribeList() throws Exception{
         //given
 
+        SubscribeDto subscribeDto = new SubscribeDto(BigInteger.valueOf(1), "t1dmlgus", null, 1, 0);
+        List<Object> ar = new ArrayList<>();
+        Object[] result_object = {BigInteger.valueOf(1), "t1dmlgus", null, 1, 0};
+        ar.add(result_object);
+
+
+        String sb = "SELECT u.id, u.username, u.profile_Image_Url, " +
+                "if((SELECT true FROM subscribe WHERE from_User_id = ? AND to_User_id = u.id), 1, 0) follow, " +
+                "if((?=u.id), 1, 0) iam " +
+                "FROM user u INNER JOIN subscribe s " +
+                "ON u.id = s.from_User_id " +
+                "WHERE s.to_User_id = ? ";
+
+        Query mockedQuery = mock(Query.class);
+
+
+        when(em.createNativeQuery(sb)).thenReturn(mockedQuery);
+        when(mockedQuery.setParameter(anyInt(), anyLong())).thenReturn(mockedQuery);
+        when(mockedQuery.getResultList()).thenReturn(ar);
+
         //when
-        List<SubscribeDto> subscribeDtos = subscribeService.subscribeList(2L, 3L);
-        for (SubscribeDto subscribeDto : subscribeDtos) {
-            System.out.println("subscribeDto = " + subscribeDto);
-        }
+        List<SubscribeDto> subscribeDtos = subscribeService.subscribeList(sessionUserId, pageUserId);
 
         //then
-        //Assertions.assertThat(subscribeDtos.get(0).getUsername()).isEqualTo("t1dmlgus");
+        assertThat(subscribeDtos.get(0).getUsername()).isEqualTo("t1dmlgus");
 
 
+
+    }
+
+    @DisplayName("구독 상태 확인 테스트")
+    @Test
+    public void getSubscribeStateTest() throws Exception{
+        //given
+        when(subscribeRepository.mSubscribeState(pageUserId, sessionUserId)).thenReturn(1);
+
+
+        //when
+        boolean subscribeState = subscribeService.getSubscribeState(pageUserId, sessionUserId);
+
+        //then
+        assertThat(subscribeState).isTrue();
+    }
+
+    @DisplayName("구독자 수 카운트 테스트")
+    @Test
+    public void getSubscribeCountTest() throws Exception{
+        //given
+
+        when(subscribeRepository.mSubscribeCount(sessionUserId)).thenReturn(2);
+
+        //when
+        int subscribeCount = subscribeService.getSubscribeCount(sessionUserId);
+
+        //then
+        assertThat(subscribeCount).isEqualTo(2);
     }
 
 

--- a/src/test/java/com/s1dmlgus/instagram02/service/SubscribeServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/SubscribeServiceUnitTest.java
@@ -1,0 +1,44 @@
+package com.s1dmlgus.instagram02.service;
+
+import com.s1dmlgus.instagram02.web.dto.subscribe.SubscribeDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Transactional
+//@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class SubscribeServiceUnitTest {
+
+    @Autowired
+    private SubscribeService subscribeService;
+
+//    @Spy
+//    private EntityManager em;
+//    @Mock
+//    private JpaResultMapper jpaResultMapper;
+//
+    @DisplayName("구독자 리스트 테스트")
+    @Test
+    public void subscribeList() throws Exception{
+        //given
+
+        //when
+        List<SubscribeDto> subscribeDtos = subscribeService.subscribeList(2L, 3L);
+        for (SubscribeDto subscribeDto : subscribeDtos) {
+            System.out.println("subscribeDto = " + subscribeDto);
+        }
+
+        //then
+        //Assertions.assertThat(subscribeDtos.get(0).getUsername()).isEqualTo("t1dmlgus");
+
+
+    }
+
+
+}

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
@@ -1,6 +1,7 @@
 package com.s1dmlgus.instagram02.service;
 
 import com.s1dmlgus.instagram02.domain.image.Image;
+import com.s1dmlgus.instagram02.domain.subscribe.SubscribeRepository;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
@@ -8,7 +9,7 @@ import com.s1dmlgus.instagram02.web.dto.ResponseDto;
 import com.s1dmlgus.instagram02.web.dto.auth.JoinRequestDto;
 import com.s1dmlgus.instagram02.web.dto.user.UserProfileResponseDto;
 import com.s1dmlgus.instagram02.web.dto.user.UserUpdateRequestDto;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +21,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -38,7 +41,17 @@ class UserServiceUnitTest {
     private UserService userService;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private SubscribeRepository subscribeRepository;
 
+    @Mock
+    private User sessionUser;
+
+    @BeforeEach
+    public void setUp(){
+
+        sessionUser = testUser();
+    }
 
     @Spy
     private BCryptPasswordEncoder bCryptPasswordEncoder;
@@ -47,8 +60,8 @@ class UserServiceUnitTest {
     @Test
     public void duplicateUsernameTest() throws Exception {
         //given
-        User user1 = testUser();
-        User user2 = testUser();
+        User user1 = sessionUser;
+        User user2 = sessionUser;
         when(userRepository.existsByUsername(user1.getUsername())).thenReturn(true);
 
         //when
@@ -65,13 +78,13 @@ class UserServiceUnitTest {
     @Test
     public void bcryptPwTest() throws Exception {
         //given
-        User user = testUser();
+
 
         //when
-        userService.bcryptPw(user);
+        userService.bcryptPw(sessionUser);
 
         //then
-        assertThat(user.getPassword()).isNotEqualTo("1234");
+        assertThat(sessionUser.getPassword()).isNotEqualTo("1234");
 
     }
 
@@ -113,17 +126,65 @@ class UserServiceUnitTest {
     @Test
     public void getProfileTest() throws Exception{
         //given
-        Long userId = 1L;
-        when(userRepository.findById(any(Long.class))).thenReturn(Optional.of(createProfile()));
+        Long pageId = 2L;
+        when(userRepository.findById(any(Long.class))).thenReturn(Optional.ofNullable(sessionUser));
+        when(subscribeRepository.mSubscribeState(pageId, sessionUser.getId())).thenReturn(1);
+        when(subscribeRepository.mSubscribeCount(pageId)).thenReturn(1);
 
+        
         //when
-        UserProfileResponseDto profile = userService.getProfile(userId, 1L);
+        UserProfileResponseDto profile = userService.getProfile(pageId, sessionUser.getId());
         logger.info("profile : {}", profile);
 
         //then
-        Assertions.assertThat(profile.getImages().get(0).getCaption()).isEqualTo("테스트이미지");
-
+        assertThat(profile.getUsername()).isEqualTo("테스트의현");
+  
     }
+    
+    @DisplayName("로그인 유저가 해당 페이지 주인인지 확인 테스트")
+    @Test
+    public void getPageOwnerStateTest() throws Exception{
+        //given
+        Long pageId = 1L;
+
+
+        //when
+        boolean pageOwnerState = userService.getPageOwnerState(pageId, sessionUser.getId());
+
+        //then
+        assertThat(pageOwnerState).isTrue();
+    }
+    
+    @DisplayName("구독 상태 확인 테스트")
+    @Test
+    public void getSubscribeStateTest() throws Exception{
+        //given
+        Long pageId = 1L;
+        when(subscribeRepository.mSubscribeState(pageId, sessionUser.getId())).thenReturn(1);
+
+
+        //when
+        boolean subscribeState = userService.getSubscribeState(pageId, sessionUser.getId());
+
+        //then
+        assertThat(subscribeState).isTrue();
+    }
+
+    @DisplayName("구독자 수 카운트 테스트")
+    @Test
+    public void getSubscribeCountTest() throws Exception{
+        //given
+
+        when(subscribeRepository.mSubscribeCount(sessionUser.getId())).thenReturn(2);
+
+        //when
+        int subscribeCount = userService.getSubscribeCount(sessionUser.getId());
+
+        //then
+        assertThat(subscribeCount).isEqualTo(2);
+    }
+
+
     
     
     // 회원정보수정 DTO
@@ -165,15 +226,14 @@ class UserServiceUnitTest {
     // 프로필dto 주입
     private User createProfile(){
 
-        User testUser = testUser();
         Image image = Image.builder()
                 .caption("테스트이미지")
                 .postImageUrl("테스트명.jpg")
-                .user(testUser)
+                .user(sessionUser)
                 .build();
-        testUser.getImages().add(image);
+        sessionUser.getImages().add(image);
 
-        return testUser;
+        return sessionUser;
 
     }
 

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
@@ -1,7 +1,6 @@
 package com.s1dmlgus.instagram02.service;
 
 import com.s1dmlgus.instagram02.domain.image.Image;
-import com.s1dmlgus.instagram02.domain.subscribe.SubscribeRepository;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.domain.user.UserRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
@@ -42,7 +41,7 @@ class UserServiceUnitTest {
     @Mock
     private UserRepository userRepository;
     @Mock
-    private SubscribeRepository subscribeRepository;
+    private SubscribeService subscribeService;
 
     @Mock
     private User sessionUser;
@@ -128,8 +127,8 @@ class UserServiceUnitTest {
         //given
         Long pageId = 2L;
         when(userRepository.findById(any(Long.class))).thenReturn(Optional.ofNullable(sessionUser));
-        when(subscribeRepository.mSubscribeState(pageId, sessionUser.getId())).thenReturn(1);
-        when(subscribeRepository.mSubscribeCount(pageId)).thenReturn(1);
+        when(subscribeService.getSubscribeState(pageId, sessionUser.getId())).thenReturn(true);
+        when(subscribeService.getSubscribeCount(pageId)).thenReturn(1);
 
         
         //when
@@ -147,44 +146,12 @@ class UserServiceUnitTest {
         //given
         Long pageId = 1L;
 
-
         //when
         boolean pageOwnerState = userService.getPageOwnerState(pageId, sessionUser.getId());
 
         //then
         assertThat(pageOwnerState).isTrue();
     }
-    
-    @DisplayName("구독 상태 확인 테스트")
-    @Test
-    public void getSubscribeStateTest() throws Exception{
-        //given
-        Long pageId = 1L;
-        when(subscribeRepository.mSubscribeState(pageId, sessionUser.getId())).thenReturn(1);
-
-
-        //when
-        boolean subscribeState = userService.getSubscribeState(pageId, sessionUser.getId());
-
-        //then
-        assertThat(subscribeState).isTrue();
-    }
-
-    @DisplayName("구독자 수 카운트 테스트")
-    @Test
-    public void getSubscribeCountTest() throws Exception{
-        //given
-
-        when(subscribeRepository.mSubscribeCount(sessionUser.getId())).thenReturn(2);
-
-        //when
-        int subscribeCount = userService.getSubscribeCount(sessionUser.getId());
-
-        //then
-        assertThat(subscribeCount).isEqualTo(2);
-    }
-
-
     
     
     // 회원정보수정 DTO


### PR DESCRIPTION
### 이슈 번호
resolved: #32 

### 개요

구독하기 구현

- 구독하기 버튼 활성화 
- 구독 API 구현

### 작업 내용

build

- QLRM 의존성 추가
  (네이티브 쿼리 -> DTO 매핑)

Subscribe.java

- 유저(User)와 구독(Subscribe) 엔티티간 1:N의 연관관계 설계
- 테이블 속성 중 하나로, DDL 생성 시 유니크 제약조건(@UniqueConstraint) 생성

SubscribeRepository.java

- 구독하기, 구독취소, 구독상태, 구독자 수 네이티브 쿼리로 작성
- 추후 queryDsl로 리펙토링 필요

SubscribeService.java

- 구독하기 기능
- 구독취소 기능
- 구독자 리스트 반환 기능
  - toUser 프로필 페이지의 팔로워 버튼 클릭 시 해당 toUser를  구독하는 유저 리스트 호출
  - 파라미터로 받은 세션유저ID와 페이지유저ID를 파라미터 바인딩(위치 기준)으로 네이티브 쿼리 생성
  - QLRM 라이브러리 이용해서 SubscribeDTO에 매핑
- 구독 상태 확인
- 구독자 수 카운트


SubscribeDto.java

- Query 매핑 시 sql에서 요구하는 Long -> BigInteger, int -> Integer로 타입변경


profile.html

- 페이지 호출 시 구독자 수와 구독상태 렌더링 
- 팔로워 버튼 클릭 시 해당 유저 페이지를 구독하는 유저리스트 API 호출
- 구독버튼 활성화

profile.js

- ajax를 사용하여 구독 API를 호출
- javascript와 css를 이용하여 구독자 리스트 비동기 처리


### 테스트

- [x] SubscribeServiceUnitTest.java
- [x] UserServiceUnitTest.java

 
### 주의사항

- Subscribe 구독 API 구현 정리 
  https://www.notion.so/4774b54c41184093ad55b04e96dcb01b 
