### PR TITLE
feat: 이미지 API[GET] - 스토리 구현 및 스토리 페이지 렌더링[ISSUE-48]

### DIFF
--- a/src/main/java/com/s1dmlgus/instagram02/domain/image/ImageRepository.java
+++ b/src/main/java/com/s1dmlgus/instagram02/domain/image/ImageRepository.java
@@ -1,11 +1,17 @@
 package com.s1dmlgus.instagram02.domain.image;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findAllByUserId(Long userId);
+
+    @Query(value = "SELECT * FROM image WHERE user_id IN (SELECT to_user_id FROM subscribe WHERE from_user_id = :principalId)", nativeQuery = true)
+    List<Image> getStory(@Param("principalId") Long principalId);
+
 
 }

--- a/src/main/java/com/s1dmlgus/instagram02/service/ImageService.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/ImageService.java
@@ -6,7 +6,9 @@ import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.domain.image.ImageRepository;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
-import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadRequestDto;
+import com.s1dmlgus.instagram02.web.dto.image.story.ImageStoryResponseDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.UUID;
 
 
@@ -35,51 +38,51 @@ public class ImageService {
 
     // 이미지 업로드
     @Transactional
-    public ResponseDto<?> upload(ImageUploadDto imageUploadDto, PrincipalDetails principalDetails){
+    public ResponseDto<?> upload(ImageUploadRequestDto imageUploadRequestDto, PrincipalDetails principalDetails){
 
         // 파일 명
-        String fileName = createFile(imageUploadDto);
+        String fileName = createFile(imageUploadRequestDto);
 
         // 파일업로드
         //uploadFile(imageUploadDto, fileName);
 
         // s3 파일 업로드
-        s3Service.upload(imageUploadDto, fileName);
+        s3Service.upload(imageUploadRequestDto, fileName);
 
 
         // 영속화
-        Image afterUploadImage = imageRepository.save(imageUploadDto.toEntity(fileName, principalDetails.getUser()));
+        Image afterUploadImage = imageRepository.save(imageUploadRequestDto.toEntity(fileName, principalDetails.getUser()));
         logger.info("[after 영속화] : {}", afterUploadImage);
 
-        return new ResponseDto<>("이미지가 업로드 되었습니다.", afterUploadImage.getId());
+        return new ResponseDto<>("이미지가 업로드 되었습니다.", new ImageUploadResponseDto(afterUploadImage));
     }
 
     // 파일명
-    protected String createFile(ImageUploadDto imageUploadDto) {
+    protected String createFile(ImageUploadRequestDto imageUploadRequestDto) {
         
         // 파일 유효성검사
-        validationFile(imageUploadDto);
+        validationFile(imageUploadRequestDto);
         // 파일명
         UUID uuid = UUID.randomUUID();
 
-        return uuid + "_" + imageUploadDto.getFile().getOriginalFilename();
+        return uuid + "_" + imageUploadRequestDto.getFile().getOriginalFilename();
     }
 
     // 유효성 검사
-    protected void validationFile(ImageUploadDto imageUploadDto) {
-        if (imageUploadDto.getFile() == null) {
+    protected void validationFile(ImageUploadRequestDto imageUploadRequestDto) {
+        if (imageUploadRequestDto.getFile() == null) {
             throw new CustomApiException("이미지가 첨부되지 않았습니다.");
         }
     }
 
     // 파일 업로드
-    protected void uploadFile(ImageUploadDto imageUploadDto, String fileName) {
+    protected void uploadFile(ImageUploadRequestDto imageUploadRequestDto, String fileName) {
 
         // 파일경로
         Path imageFilePath = Paths.get(uploadFolder + fileName);
 
         try {
-            Files.write(imageFilePath, imageUploadDto.getFile().getBytes());
+            Files.write(imageFilePath, imageUploadRequestDto.getFile().getBytes());
 
         } catch (Exception e) {
             throw new CustomApiException("이미지 업로드에 실패했습니다.");
@@ -87,6 +90,13 @@ public class ImageService {
         }
     }
 
+    // 스토리 가져오기
+    @Transactional(readOnly = true)
+    public ResponseDto<?> getStory(PrincipalDetails principalDetails) {
 
+        List<Image> story = imageRepository.getStory(principalDetails.getUser().getId());
 
+        return new ResponseDto<>("이미지 스토리를 가져옵니다.", ImageStoryResponseDto.imageStoryResponseDtoList(story, 0));
+
+    }
 }

--- a/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
+++ b/src/main/java/com/s1dmlgus/instagram02/service/S3Service.java
@@ -10,7 +10,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
-import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadRequestDto;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -50,14 +50,14 @@ public class S3Service {
 
     // s3 업로드
     @Transactional
-    public void upload(ImageUploadDto imageUploadDto, String fileName){
+    public void upload(ImageUploadRequestDto imageUploadRequestDto, String fileName){
 
         try {
             ObjectMetadata objMeta = new ObjectMetadata();
-            byte[] bytes = IOUtils.toByteArray(imageUploadDto.getFile().getInputStream());
+            byte[] bytes = IOUtils.toByteArray(imageUploadRequestDto.getFile().getInputStream());
             objMeta.setContentLength(bytes.length);
 
-            s3Client.putObject(new PutObjectRequest(bucket, fileName, imageUploadDto.getFile().getInputStream(), objMeta)
+            s3Client.putObject(new PutObjectRequest(bucket, fileName, imageUploadRequestDto.getFile().getInputStream(), objMeta)
                     .withCannedAcl(CannedAccessControlList.PublicRead));
         } catch (Exception e) {
             //e.printStackTrace();

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/ImageController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/ImageController.java
@@ -17,8 +17,9 @@ public class ImageController {
 
 
     @GetMapping("/")
-    public String index() {
+    public String index(@AuthenticationPrincipal PrincipalDetails principalDetails, Model model) {
 
+        model.addAttribute("principal", principalDetails);
         return "image/story";
     }
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiController.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiController.java
@@ -4,7 +4,7 @@ package com.s1dmlgus.instagram02.web.controller.api;
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
 import com.s1dmlgus.instagram02.service.ImageService;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
-import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadRequestDto;
 import lombok.RequiredArgsConstructor;
 
 import org.slf4j.Logger;
@@ -16,10 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.WebDataBinder;
-import org.springframework.web.bind.annotation.InitBinder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
@@ -33,16 +30,28 @@ public class ImageApiController {
 
     Logger logger = LoggerFactory.getLogger(ImageApiController.class);
 
-
     private final ImageService imageService;
 
-    @PostMapping("/save")
-    public ResponseEntity<?> imageUpload(@Valid ImageUploadDto imageUploadDto, BindingResult bindingResult, @AuthenticationPrincipal PrincipalDetails principalDetails) {
 
-        logger.info("immageUploadDto {}", imageUploadDto);
+    // 스토리
+    @GetMapping()
+    public ResponseEntity<?> story(@AuthenticationPrincipal PrincipalDetails principalDetails){
+
+        ResponseDto<?> story = imageService.getStory(principalDetails);
+        logger.info("story : {}", story);
+
+        return new ResponseEntity<>(story, HttpStatus.OK);
+    }
+
+
+    // 업로드
+    @PostMapping("/save")
+    public ResponseEntity<?> imageUpload(@Valid ImageUploadRequestDto imageUploadRequestDto, BindingResult bindingResult, @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        logger.info("immageUploadDto {}", imageUploadRequestDto);
 
         // 업로드
-        ResponseDto<?> uploadImage = imageService.upload(imageUploadDto, principalDetails);
+        ResponseDto<?> uploadImage = imageService.upload(imageUploadRequestDto, principalDetails);
 
         logger.info("[이미지 업로드 완료] uploadImage : {}", uploadImage);
 

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/image/story/ImageStoryResponseDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/image/story/ImageStoryResponseDto.java
@@ -1,0 +1,50 @@
+package com.s1dmlgus.instagram02.web.dto.image.story;
+
+import com.s1dmlgus.instagram02.domain.image.Image;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class ImageStoryResponseDto {
+
+    private Long imageId;
+    private String caption;
+    private String postImageUrl;
+    private String username;
+    private LocalDateTime createdDate;
+    private int likeCount;
+    private boolean likeState;
+
+
+    public ImageStoryResponseDto(Image uploadImage, int likeCount) {
+
+        this.imageId = uploadImage.getId();
+        this.createdDate = uploadImage.getCreatedDate();
+        this.caption = uploadImage.getCaption();
+        this.postImageUrl = uploadImage.getPostImageUrl();
+        this.username = uploadImage.getUser().getUsername();
+
+
+    }
+
+    // story
+    public static List<ImageStoryResponseDto> imageStoryResponseDtoList(List<Image> storyImage, int likeCount) {
+
+        List<ImageStoryResponseDto> ar = new ArrayList<>();
+        for (Image image : storyImage) {
+            ar.add(new ImageStoryResponseDto(image, likeCount));
+        }
+
+        return ar;
+    }
+
+
+}

--- a/src/main/java/com/s1dmlgus/instagram02/web/dto/image/upload/ImageUploadRequestDto.java
+++ b/src/main/java/com/s1dmlgus/instagram02/web/dto/image/upload/ImageUploadRequestDto.java
@@ -1,4 +1,4 @@
-package com.s1dmlgus.instagram02.web.dto.image;
+package com.s1dmlgus.instagram02.web.dto.image.upload;
 
 import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.domain.user.User;
@@ -16,7 +16,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-public class ImageUploadDto {
+public class ImageUploadRequestDto {
 
     private String userId;
     @NotBlank(message = "타이틀을 입력해주세요.")

--- a/src/main/resources/static/js/story.js
+++ b/src/main/resources/static/js/story.js
@@ -10,10 +10,80 @@
 // (1) 스토리 로드하기
 function storyLoad() {
 
+    $.ajax({
+        type:"get",
+        url:`/api/image`,
+        dataType:'json'
+
+    }).done(res=>{
+
+        console.log(res);
+        res.data.forEach((image)=>{
+
+            let storyItem = getStoryItem(image);
+            $("#storyList").append(storyItem);
+        });
+
+    }).fail(error=>{
+        console.log(error);
+        alert(error.responseJSON.message);
+
+    });
+
+
 }
 
-function getStoryItem() {
+storyLoad();
 
+function getStoryItem(image) {
+
+    let item = `
+            <div class="story-list__item">
+                <div class="sl__item__header">
+                    <div>
+                        <img class="profile-image" src="${image.postImageUrl}"
+                             onerror="this.src='/images/person.jpeg'" />
+                    </div>
+                    <div>${image.username}</div>
+                </div>
+
+                <div class="sl__item__img">
+                    <img src="${image.postImageUrl}" />
+                </div>
+
+                <div class="sl__item__contents">
+                    <div class="sl__item__contents__icon">
+
+                        <button>
+                            <i class="fas fa-heart active" id="storyLikeIcon-1" onclick="toggleLike()"></i>
+                        </button>
+                    </div>
+
+                    <span class="like"><b id="storyLikeCount-1">3 </b>likes</span>
+
+                    <div class="sl__item__contents__content">
+                        <p>등산하는 것이 너무 재밌네요</p>
+                    </div>
+
+                    <div id="storyCommentList-1">
+
+                        <div class="sl__item__contents__comment" id="storyCommentItem-1">
+                        <p>
+                            <b>Lovely :</b> 부럽습니다.
+                        </p>
+                        <button>
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                </div>
+                <div class="sl__item__input">
+                    <input type="text" placeholder="댓글 달기..." id="storyCommentInput-1" />
+                    <button type="button" onClick="addComment()">게시</button>
+                </div>
+            </div>
+       </div>`;
+
+    return item;
 }
 
 // (2) 스토리 스크롤 페이징하기

--- a/src/main/resources/templates/image/story.html
+++ b/src/main/resources/templates/image/story.html
@@ -11,50 +11,7 @@
 		<article class="story-list" id="storyList">
 
 			<!--전체 리스트 아이템-->
-			<div class="story-list__item">
-				<div class="sl__item__header">
-					<div>
-						<img class="profile-image" src="#"
-							 onerror="this.src='/images/person.jpeg'" />
-					</div>
-					<div>TherePrograming</div>
-				</div>
 
-				<div class="sl__item__img">
-					<img src="/images/home.jpg" />
-				</div>
-
-				<div class="sl__item__contents">
-					<div class="sl__item__contents__icon">
-
-						<button>
-							<i class="fas fa-heart active" id="storyLikeIcon-1" onclick="toggleLike()"></i>
-						</button>
-					</div>
-
-					<span class="like"><b id="storyLikeCount-1">3 </b>likes</span>
-
-					<div class="sl__item__contents__content">
-						<p>등산하는 것이 너무 재밌네요</p>
-					</div>
-
-					<div id="storyCommentList-1">
-
-						<div class="sl__item__contents__comment" id="storyCommentItem-1">
-						<p>
-							<b>Lovely :</b> 부럽습니다.
-						</p>
-						<button>
-							<i class="fas fa-times"></i>
-						</button>
-					</div>
-				</div>
-				<div class="sl__item__input">
-					<input type="text" placeholder="댓글 달기..." id="storyCommentInput-1" />
-					<button type="button" onClick="addComment()">게시</button>
-				</div>
-			</div>
-			</div>
 		</article>
 	</section>
 </main>

--- a/src/test/java/com/s1dmlgus/instagram02/service/ImageServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/ImageServiceUnitTest.java
@@ -2,11 +2,13 @@ package com.s1dmlgus.instagram02.service;
 
 
 import com.s1dmlgus.instagram02.config.auth.PrincipalDetails;
+import com.s1dmlgus.instagram02.domain.image.Image;
 import com.s1dmlgus.instagram02.domain.image.ImageRepository;
 import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.handler.exception.CustomApiException;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
-import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadRequestDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,21 +17,27 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
 
 
 @Transactional
 @ExtendWith(MockitoExtension.class)
 class ImageServiceUnitTest {
+
+    Logger logger = LoggerFactory.getLogger(ImageServiceUnitTest.class);
 
 
     @Spy
@@ -41,20 +49,12 @@ class ImageServiceUnitTest {
     @Mock
     private ImageRepository imageRepository;
 
-    @Mock
-    private PrincipalDetails principalDetails;
-
+    private User user;
 
     @BeforeEach
     public void setUp(){
-        User user = User.builder()
-                .username("t1dmlgus")
-                .password("1234")
-                .email("dmlgus@gamil.com")
-                .name("이의현")
-                .build();
-
-        principalDetails.setUser(user);
+        user = new User();
+        user.testUser();
 
         ReflectionTestUtils.setField(imageService, "uploadFolder", "C:/workspace/springbootwork/upload/");
     }
@@ -67,15 +67,16 @@ class ImageServiceUnitTest {
 
         //given
         MockMultipartFile file = new MockMultipartFile("테스트파일", "테스트파일명.jpeg", "image/jpeg", "<<테스트파일>>".getBytes());
-        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", file);
+        ImageUploadRequestDto imageUploadRequestDto = new ImageUploadRequestDto("1L", "이미지업로드테스트입니다", file);
 
-
-        when(imageService.createFile(imageUploadDto)).thenReturn("uuid_테스트명");
+        when(imageService.createFile(imageUploadRequestDto)).thenReturn("uuid_테스트명");
         doNothing().when(s3Service).upload(any(), eq("uuid_테스트명"));
-        when(imageRepository.save(any())).thenReturn(imageUploadDto.toEntity(eq("uuid_테스트명"),any()));
+        doReturn(new Image(1L, "이미지업로드테스트입니다", "https://d3r3itann8ixvx.cloudfront.net/uuid_테스트명", user)).when(imageRepository).save(any());
         
         //when
-        ResponseDto<?> upload = imageService.upload(imageUploadDto, principalDetails);
+        ResponseDto<?> upload = imageService.upload(imageUploadRequestDto, new PrincipalDetails(user));
+
+        logger.info("upload : {}", upload);
 
         //then
         assertThat(upload.getMessage()).isEqualTo("이미지가 업로드 되었습니다.");
@@ -88,10 +89,10 @@ class ImageServiceUnitTest {
     public void createFileTest() throws Exception{
         //given
         MockMultipartFile file = new MockMultipartFile("파일제목", "파일제목.jpeg", "image/jpeg", "<<jpeg data>>".getBytes());
-        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", file);
+        ImageUploadRequestDto imageUploadRequestDto = new ImageUploadRequestDto("1L", "이미지업로드테스트입니다", file);
 
         //when
-        String fileName = imageService.createFile(imageUploadDto);
+        String fileName = imageService.createFile(imageUploadRequestDto);
 
         //then
         assertThat(fileName).contains("파일제목.jpeg");
@@ -104,12 +105,12 @@ class ImageServiceUnitTest {
     public void validationFileTest() throws Exception{
         //given
         MockMultipartFile file = null;
-        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", file);
+        ImageUploadRequestDto imageUploadRequestDto = new ImageUploadRequestDto("1L", "이미지업로드테스트입니다", file);
 
         //when
 
         //then
-        assertThatThrownBy(() -> imageService.validationFile(imageUploadDto))
+        assertThatThrownBy(() -> imageService.validationFile(imageUploadRequestDto))
                 .isInstanceOf(CustomApiException.class)
                 .hasMessage("이미지가 첨부되지 않았습니다.");
 
@@ -120,16 +121,37 @@ class ImageServiceUnitTest {
     public void uploadFileTest() throws Exception{
         //given
         MockMultipartFile file = new MockMultipartFile("파일제목", "파일제목.jpeg", "image/jpeg", "<<jpeg data>>".getBytes());
-        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", null);
+        ImageUploadRequestDto imageUploadRequestDto = new ImageUploadRequestDto("1L", "이미지업로드테스트입니다", null);
 
         //when
 
         
         //then
-        assertThatThrownBy(() -> imageService.uploadFile(imageUploadDto, "hi"))
+        assertThatThrownBy(() -> imageService.uploadFile(imageUploadRequestDto, "hi"))
                 .isInstanceOf(CustomApiException.class)
                 .hasMessage("이미지 업로드에 실패했습니다.");
 
     }
+
+    @DisplayName("스토리 가져오기 테스트")
+    @Test
+    public void storyTest() throws Exception{
+        //given
+        List<Image> testAr = new ArrayList<>();
+        testAr.add(new Image(1L, "테스트01", "31a06720-7e1b-4388-a241-4e246c6a94b8_1.jpg", User.builder().username("t2dmlgus").build()));
+        testAr.add(new Image(2L, "테스트02", "31a06720-7e1b-4388-a241-4e246c6a94b8_2.jpg", User.builder().username("t3dmlgus").build()));
+
+        when(imageRepository.getStory(anyLong())).thenReturn(testAr);
+
+        //when
+        ResponseDto<?> story = imageService.getStory(new PrincipalDetails(user));
+
+        logger.info("story : {}", story);
+
+        //then
+        Assertions.assertThat(story.getMessage()).isEqualTo("이미지 스토리를 가져옵니다.");
+
+    }
+
 
 }

--- a/src/test/java/com/s1dmlgus/instagram02/service/S3ServiceTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/S3ServiceTest.java
@@ -1,6 +1,6 @@
 package com.s1dmlgus.instagram02.service;
 
-import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,13 +27,13 @@ class S3ServiceTest {
     public void failS3UploadTest() throws Exception{
         //given
         MockMultipartFile file = new MockMultipartFile("테스트파일", "테스트파일명.jpeg", "image/jpeg", "<<테스트파일>>".getBytes());
-        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", file);
+        ImageUploadRequestDto imageUploadRequestDto = new ImageUploadRequestDto("1L", "이미지업로드테스트입니다", file);
         String fileName = "uuid_테스트명";
 
         //when
 
         //then
-        assertThatThrownBy(() -> s3Service.upload(imageUploadDto, fileName))
+        assertThatThrownBy(() -> s3Service.upload(imageUploadRequestDto, fileName))
                 .isInstanceOf(Exception.class)
                 .hasMessage("s3 이미지 업로드에 실패하였습니다.");
 

--- a/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/service/UserServiceUnitTest.java
@@ -183,7 +183,7 @@ class UserServiceUnitTest {
     private User testUser() {
 
         User user = new User();
-        user.testUser("test1Dmlgus", "1234", "dmlgus@gmail.com", "테스트의현");
+        user.testUser();
 
         return user;
     }

--- a/src/test/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiControllerUnitTest.java
+++ b/src/test/java/com/s1dmlgus/instagram02/web/controller/api/ImageApiControllerUnitTest.java
@@ -1,16 +1,16 @@
 package com.s1dmlgus.instagram02.web.controller.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.s1dmlgus.instagram02.config.SecurityConfig;
+import com.s1dmlgus.instagram02.domain.image.Image;
+import com.s1dmlgus.instagram02.domain.user.User;
 import com.s1dmlgus.instagram02.service.ImageService;
-import com.s1dmlgus.instagram02.service.UserService;
 import com.s1dmlgus.instagram02.web.dto.ResponseDto;
-import com.s1dmlgus.instagram02.web.dto.image.ImageUploadDto;
+import com.s1dmlgus.instagram02.web.dto.image.story.ImageStoryResponseDto;
+import com.s1dmlgus.instagram02.web.dto.image.upload.ImageUploadRequestDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Spy;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
@@ -19,24 +19,24 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentRequest;
 import static com.s1dmlgus.instagram02.common.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @ExtendWith(RestDocumentationExtension.class)    // JUnit5 필수
@@ -62,13 +62,9 @@ class ImageApiControllerUnitTest {
     public void imageUploadTest() throws Exception{
         //given
         MockMultipartFile files = new MockMultipartFile("file", "파일명.jpeg", "image/jpeg", "<<파일데이터>>".getBytes());
-        ImageUploadDto imageUploadDto = new ImageUploadDto("1L", "이미지업로드테스트입니다", files);
+        ImageUploadRequestDto imageUploadRequestDto = new ImageUploadRequestDto("1L", "이미지업로드테스트입니다", files);
 
         //when
-        when(imageService.upload(any(ImageUploadDto.class), any())).thenReturn(new ResponseDto<>("이미지가 업로드 되었습니다.", null));
-
-
-        //then
         ResultActions resultActions = mockMvc.perform(
                 multipart("/api/image/save")
                         .file(files)
@@ -79,6 +75,8 @@ class ImageApiControllerUnitTest {
                         .characterEncoding("utf-8")
         );
 
+
+        //then
         resultActions
                 .andExpect(status().isOk())
                 .andDo(MockMvcResultHandlers.print())
@@ -88,4 +86,33 @@ class ImageApiControllerUnitTest {
 
     }
 
+    
+    @DisplayName("스토리 가져오기 테스트")
+    @Test
+    public void getStoryTest() throws Exception{
+        //given
+
+        List<Image> testAr = new ArrayList<>();
+        testAr.add(new Image(1L, "테스트01", "31a06720-7e1b-4388-a241-4e246c6a94b8_1.jpg", User.builder().username("t2dmlgus").build()));
+        testAr.add(new Image(2L, "테스트02", "31a06720-7e1b-4388-a241-4e246c6a94b8_2.jpg", User.builder().username("t3dmlgus").build()));
+
+        doReturn(new ResponseDto<>("이미지 스토리를 가져옵니다.", ImageStoryResponseDto.imageStoryResponseDtoList(testAr, 0)))
+                .when(imageService).getStory(any());
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/image")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON_UTF8)
+                        .characterEncoding("utf-8")
+        );
+
+
+
+        //then
+         resultActions
+                        .andExpect(status().isOk())
+                        .andDo(MockMvcResultHandlers.print());
+    }
+    
 }


### PR DESCRIPTION
### 이슈 번호
resolved: #48 

### 개요

- 이미지 API[GET] - 스토리 구현
- 스토리 페이지 렌더링

### 작업 내용

ImageService.java

- imageRepository 를 통해 반환된 이미지엔티티와 추후 구현할 좋아요 개수를 ImageStoryResponseDto에 매핑한다.


ImageStoryResponseDto.java

- List 형식의 엔티티를 DTO로 변환한다.

story.js

- 이미지 API로 반환받은 데이터를 getStoryItem() 메서드의 인수로 넘겨준다.
- 스토리 페이지 호출 시 인수로 넘겨준 데이터를 렌더링한다.




### 테스트

- [X] ImageServiceUnitTest.java
- [X] ImageApiControllerUnitTest

### 주의사항

- Transaction(readOnly = true)
- 각 API별 넘겨줄 데이터를 토대로 DTO를 생성한다.

